### PR TITLE
Exception Handler 구현

### DIFF
--- a/src/main/java/com/example/dearfam/DearfamApplication.java
+++ b/src/main/java/com/example/dearfam/DearfamApplication.java
@@ -2,8 +2,10 @@ package com.example.dearfam;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class DearfamApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/dearfam/common/configuration/security/SecurityConfiguration.java
+++ b/src/main/java/com/example/dearfam/common/configuration/security/SecurityConfiguration.java
@@ -46,7 +46,7 @@ public class SecurityConfiguration {
                         authorize -> authorize
                                 .requestMatchers(request -> request.getRequestURI().startsWith("/swagger-ui")).permitAll()
                                 .requestMatchers(request -> request.getRequestURI().startsWith("/v3/api-docs")).permitAll()
-                                .requestMatchers(AntPathRequestMatcher.antMatcher("/dev/**")).authenticated()
+                                .requestMatchers(AntPathRequestMatcher.antMatcher("/dev/**")).permitAll()
                                 .requestMatchers(request -> request.getRequestURI().startsWith("/h2-console")).permitAll()
                                 .anyRequest().authenticated()
                 )

--- a/src/main/java/com/example/dearfam/common/dto/exception/ApiResponseError.java
+++ b/src/main/java/com/example/dearfam/common/dto/exception/ApiResponseError.java
@@ -1,0 +1,52 @@
+package com.example.dearfam.common.dto.exception;
+
+import com.example.dearfam.common.exception.CustomException;
+import com.example.dearfam.common.exception.errorcode.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import lombok.Builder;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ *
+ * @param code 에러 코드 명
+ * @param status 상태 코드 값
+ * @param name 오류 이름
+ * @param message 오류 메시지
+ * @param cause
+ * @param timestamp 발생 시각
+ */
+
+@Builder
+public record ApiResponseError(
+        String code,
+        Integer status,
+        String name,
+        String message,
+        @JsonInclude(Include.NON_EMPTY)List<ApiSimpleError> cause,
+        Instant timestamp
+) {
+    public static ApiResponseError of(CustomException exception) {
+        ErrorCode errorCode = exception.getErrorCode();
+        String errorName = exception.getClass().getName();
+        errorName = errorName.substring(errorName.lastIndexOf(".") + 1);
+
+        return ApiResponseError.builder()
+                .code(errorCode.name())
+                .status(errorCode.defaultHttpStatus().value())
+                .name(errorName)
+                .message(exception.getMessage())
+                .cause(ApiSimpleError.listOfCauseSimpleError(exception.getCause()))
+                .build();
+    }
+
+    public ApiResponseError {
+        if (code == null) code = "API ERROR";
+        if (status == null) status = 500;
+        if (name == null) name = "ApiError";
+        if (message == null||message.isBlank()) message = "Api 오류";
+        if (timestamp == null) timestamp = Instant.now();
+    }
+}

--- a/src/main/java/com/example/dearfam/common/dto/exception/ApiSimpleError.java
+++ b/src/main/java/com/example/dearfam/common/dto/exception/ApiSimpleError.java
@@ -1,0 +1,38 @@
+package com.example.dearfam.common.dto.exception;
+
+import lombok.Builder;
+import lombok.NonNull;
+
+import java.util.List;
+
+@Builder
+public record ApiSimpleError(@NonNull String field, @NonNull String message) {
+    public static List<ApiSimpleError> listOfCauseSimpleError(Throwable cause) {
+        return List.of(arrayOfCauseSimpleError(cause));
+    }
+
+    public static ApiSimpleError[] arrayOfCauseSimpleError(Throwable cause) {
+        int depth = 0;
+        ApiSimpleError[] subErrors;
+        Throwable currentCause = cause; // 현재 예외를 저장
+
+        while (currentCause != null) { // 예외 체인의 깊이 계산
+            currentCause = currentCause.getCause();
+            depth++;
+        }
+
+        subErrors = new ApiSimpleError[depth]; // 예외 깊이만큼 배열 생성
+        currentCause = cause; // 다시 초기화 (예외를 따라가며 저장하기 위해)
+
+        for (int i = 0; i < depth; i++) { // 예외 깊이만큼 반복
+            String errorFullName = currentCause.getClass().getSimpleName(); // 예외 타입(클래스) 이름 가져옴
+            String field = errorFullName.substring(errorFullName.lastIndexOf('.') + 1); //클래스가 패키지 포함된 이름일 경우를 대비한 코드
+            subErrors[i] = ApiSimpleError.builder()
+                    .field(field)
+                    .message(currentCause.getLocalizedMessage() != null ? currentCause.getLocalizedMessage() : "No message provided")
+                    .build();
+        }
+
+        return subErrors;
+    }
+}

--- a/src/main/java/com/example/dearfam/common/exception/CustomException.java
+++ b/src/main/java/com/example/dearfam/common/exception/CustomException.java
@@ -1,0 +1,72 @@
+package com.example.dearfam.common.exception;
+
+import com.example.dearfam.common.exception.errorcode.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class CustomException extends RuntimeException {
+
+    protected ErrorCode ERROR_CODE;
+
+    private static ErrorCode getDefaultErrorCode() {
+        return DefaultErrorCodeHolder.DEFAULT_ERROR_CODE;
+    }
+
+    private static class DefaultErrorCodeHolder {
+        private static final ErrorCode DEFAULT_ERROR_CODE = new ErrorCode() {
+            @Override
+            public String name() {
+                return "SERVER_ERROR";
+            }
+
+            @Override
+            public HttpStatus defaultHttpStatus() {
+                return HttpStatus.INTERNAL_SERVER_ERROR;
+            }
+
+            @Override
+            public String defaultMessage() {
+                return "서버 오류";
+            }
+
+            @Override
+            public RuntimeException defaultException() {
+                return new CustomException("SERVER_ERROR");
+            }
+
+            @Override
+            public RuntimeException defaultException(Throwable cause) {
+                return new CustomException("SERVER_ERROR", cause);
+            }
+        };
+
+    }
+    public CustomException() {
+        this.ERROR_CODE = getDefaultErrorCode();
+    }
+
+    public CustomException(String message) {
+        super(message);
+        this.ERROR_CODE = getDefaultErrorCode();
+    }
+
+    public CustomException(String message, Throwable cause) {
+        super(message, cause);
+        this.ERROR_CODE = getDefaultErrorCode();
+    }
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.defaultMessage());
+        this.ERROR_CODE = errorCode;
+    }
+
+    public CustomException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.defaultMessage(), cause);
+        this.ERROR_CODE = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return ERROR_CODE;
+    }
+
+
+}

--- a/src/main/java/com/example/dearfam/common/exception/NoContentException.java
+++ b/src/main/java/com/example/dearfam/common/exception/NoContentException.java
@@ -1,0 +1,56 @@
+package com.example.dearfam.common.exception;
+
+import com.example.dearfam.common.exception.errorcode.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class NoContentException extends CustomException {
+
+    public NoContentException() {
+        super(new NoContentErrorCode());
+    }
+
+    public NoContentException(String message) {
+        super(new NoContentErrorCode(message));
+    }
+
+    public NoContentException(String message, Throwable cause) {
+        super(new NoContentErrorCode(message), cause);
+    }
+
+    private static class NoContentErrorCode implements ErrorCode {
+        private final String message;
+
+        public NoContentErrorCode() {
+            this.message = "요청한 데이터가 없습니다.";
+        }
+
+        public NoContentErrorCode(String message) {
+            this.message = message;
+        }
+
+        @Override
+        public String name() {
+            return "NO_CONTENT";
+        }
+
+        @Override
+        public HttpStatus defaultHttpStatus() {
+            return HttpStatus.NO_CONTENT;
+        }
+
+        @Override
+        public String defaultMessage() {
+            return message;
+        }
+
+        @Override
+        public RuntimeException defaultException() {
+            return new NoContentException();
+        }
+
+        @Override
+        public RuntimeException defaultException(Throwable cause) {
+            return new NoContentException(message, cause);
+        }
+    }
+}

--- a/src/main/java/com/example/dearfam/common/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/example/dearfam/common/exception/errorcode/ErrorCode.java
@@ -1,0 +1,11 @@
+package com.example.dearfam.common.exception.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    String name();
+    HttpStatus defaultHttpStatus();
+    String defaultMessage();
+    RuntimeException defaultException();
+    RuntimeException defaultException(Throwable cause);
+}

--- a/src/main/java/com/example/dearfam/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/dearfam/common/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,29 @@
+package com.example.dearfam.common.exception.handler;
+
+import com.example.dearfam.common.dto.exception.ApiResponseError;
+import com.example.dearfam.common.exception.CustomException;
+import com.example.dearfam.common.exception.NoContentException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public final class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponseError> handleException(CustomException exception) {
+        ApiResponseError responseError = ApiResponseError.of(exception);
+        HttpStatus httpStatus = exception
+                .getErrorCode()
+                .defaultHttpStatus();
+
+        return new ResponseEntity<>(responseError, httpStatus);
+    }
+
+    @ExceptionHandler(NoContentException.class)
+    public ResponseEntity<?> handleNoContentException(NoContentException exception) {
+        return ResponseEntity.noContent().build();
+    }
+
+}


### PR DESCRIPTION
### 1. ErrorCode 인터페이스
* Interface로 상위에서 묶고, 하위에서 enum으로 나눔
* 추후 에러 코드도 도메인별로 나누고, 도메인의 ErrorCode enum 클래스를 통해 여러 상황에 맞는 에러 코드 구현
* 에러 코드에 맞게 Exception 클래스를 구현하여 관리하기 편하게 구현함.

### 2. CustomException 클래스
* 도메인 Exception 클래스의 상위 클래스
* 기본적으로 500 에러가 설정돼있음

### 3. GlobalExceptionHandler 클래스
* 전역 예외처리 담당 클래스 구현
* ApiResponseError 객체를 생성하여 예외 처리

### 4. NoContentException 클래스
* 리소스를 찾을 수 없거나, 처리할 데이터가 없을 때 발생하는 예외
* ErrorCode를 활용하여 "NO_CONTENT" 에러 코드와 HTTP 204 응답을 반환

### 5. ApiSimpleError 레코드
* 예외의 depth 를 판별하여 depth 만큼의 배열을 만들어 예외를 배열 형식으로 저장해 반환

### 6. ApiResponseError 레코드
* 예외를 처리하는 Exception Response DTO 역할