### PR TITLE
Exception Handler 테스트 코드 구현 및 코드 수정

### DIFF
--- a/src/main/java/com/example/dearfam/common/dto/exception/ApiSimpleError.java
+++ b/src/main/java/com/example/dearfam/common/dto/exception/ApiSimpleError.java
@@ -31,6 +31,9 @@ public record ApiSimpleError(@NonNull String field, @NonNull String message) {
                     .field(field)
                     .message(currentCause.getLocalizedMessage() != null ? currentCause.getLocalizedMessage() : "No message provided")
                     .build();
+
+            // currentCause를 갱신해야, 예외체인에 대한 탐색이 올바르게 진행됨
+            currentCause = currentCause.getCause();
         }
 
         return subErrors;

--- a/src/test/java/com/example/dearfam/common/dto/exception/ApiResponseErrorTest.java
+++ b/src/test/java/com/example/dearfam/common/dto/exception/ApiResponseErrorTest.java
@@ -1,0 +1,51 @@
+package com.example.dearfam.common.dto.exception;
+
+import com.example.dearfam.common.exception.CustomException;
+import com.example.dearfam.common.exception.errorcode.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ApiResponseErrorTest {
+
+    @Test
+    void of_ShouldCreateApiResponseError_FromCustomException() {
+        // CustomException 에러 발생 시, ApiResponseError 객체가 잘 생성되는지 확인하는 테스트 코드
+        CustomException exception = new CustomException(new TestErrorCode());
+        ApiResponseError responseError = ApiResponseError.of(exception);
+
+        assertThat(responseError).isNotNull();
+        assertThat(responseError.code()).isEqualTo("TEST_ERROR");
+        assertThat(responseError.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        assertThat(responseError.message()).isEqualTo("테스트 에러 발생");
+    }
+
+    private static class TestErrorCode implements ErrorCode {
+        @Override
+        public String name() {
+            return "TEST_ERROR";
+        }
+
+        @Override
+        public HttpStatus defaultHttpStatus() {
+            return HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+
+        @Override
+        public String defaultMessage() {
+            return "테스트 에러 발생";
+        }
+
+        @Override
+        public RuntimeException defaultException() {
+            return new CustomException(this);
+        }
+
+        @Override
+        public RuntimeException defaultException(Throwable cause) {
+            return new CustomException(this, cause);
+        }
+    }
+}

--- a/src/test/java/com/example/dearfam/common/dto/exception/ApiSimpleErrorTest.java
+++ b/src/test/java/com/example/dearfam/common/dto/exception/ApiSimpleErrorTest.java
@@ -1,0 +1,50 @@
+package com.example.dearfam.common.dto.exception;
+
+import com.example.dearfam.common.exception.CustomException;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApiSimpleErrorTest {
+
+    @Test
+    void shouldConvertExceptionToSimpleError_메시지없는기본버전() {
+        Throwable cause = new CustomException();
+
+        List<ApiSimpleError> simpleErrorList = ApiSimpleError.listOfCauseSimpleError(cause);
+
+        assertThat(simpleErrorList).hasSize(1);
+        assertThat(simpleErrorList.get(0).field()).isEqualTo("CustomException");
+        assertThat(simpleErrorList.get(0).message()).isEqualTo("No message provided");
+    }
+
+    @Test
+    void shouldConvertExceptionToSimpleError_메시지있는버전() {
+        Throwable cause = new CustomException("ApiSimpleError 클래스 테스트 중");
+
+        List<ApiSimpleError> simpleErrorList = ApiSimpleError.listOfCauseSimpleError(cause);
+
+        assertThat(simpleErrorList).hasSize(1);
+        assertThat(simpleErrorList.get(0).field()).isEqualTo("CustomException");
+        assertThat(simpleErrorList.get(0).message()).isEqualTo("ApiSimpleError 클래스 테스트 중");
+    }
+
+    @Test
+    void shouldConvertExceptionToSimpleError_에러깊이2단계() {
+        // depth가 2인 경우에도 예외가 잘 처리되는지 확인하는 테스트 코드
+        Throwable cause = new CustomException("depth 2 예외");
+        Throwable cause2 = new RuntimeException("depth 1 예외", cause);
+        List<ApiSimpleError> simpleErrorList = ApiSimpleError.listOfCauseSimpleError(cause2);
+
+        assertThat(simpleErrorList).hasSize(2);
+        assertThat(simpleErrorList.get(0).field()).isEqualTo("RuntimeException");
+        assertThat(simpleErrorList.get(0).message()).isEqualTo("depth 1 예외");
+
+        System.out.println(simpleErrorList);
+
+        assertThat(simpleErrorList.get(1).field()).isEqualTo("CustomException");
+        assertThat(simpleErrorList.get(1).message()).isEqualTo("depth 2 예외");
+    }
+}

--- a/src/test/java/com/example/dearfam/common/exception/CustomExceptionTest.java
+++ b/src/test/java/com/example/dearfam/common/exception/CustomExceptionTest.java
@@ -1,0 +1,63 @@
+package com.example.dearfam.common.exception;
+
+import com.example.dearfam.common.exception.errorcode.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class CustomExceptionTest {
+
+    @Test
+    void shouldCreateCustomExceptionWithDefaultErrorCode() {
+        CustomException customException = new CustomException();
+
+        assertThat(customException.getErrorCode().name()).isEqualTo("SERVER_ERROR");
+        assertThat(customException.getErrorCode().defaultMessage()).isEqualTo("서버 오류");
+    }
+
+    @Test
+    void shouldCreateCustomExceptionWithErrorCode() {
+        CustomException customException = new CustomException("메시지 테스트");
+
+        assertThat(customException.getMessage()).isEqualTo("메시지 테스트");
+    }
+
+    @Test
+    void shouldCreateCustomExceptionWithTestErrorCode() {
+        ErrorCode errorCode = new TestErrorCode();
+        CustomException customException = new CustomException(errorCode);
+
+        assertThat(customException.getMessage()).isEqualTo("테스트 에러 발생");
+        assertThat(customException.getErrorCode().defaultMessage()).isEqualTo("테스트 에러 발생");
+        assertThat(customException.getErrorCode().defaultHttpStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    private static class TestErrorCode implements ErrorCode {
+        @Override
+        public String name() {
+            return "TEST_ERROR";
+        }
+
+        @Override
+        public HttpStatus defaultHttpStatus() {
+            return HttpStatus.BAD_REQUEST;
+        }
+
+        @Override
+        public String defaultMessage() {
+            return "테스트 에러 발생";
+        }
+
+        @Override
+        public RuntimeException defaultException() {
+            return new CustomException(this);
+        }
+
+        @Override
+        public RuntimeException defaultException(Throwable cause) {
+            return new CustomException(this, cause);
+        }
+    }
+}

--- a/src/test/java/com/example/dearfam/common/exception/NoContentExceptionTest.java
+++ b/src/test/java/com/example/dearfam/common/exception/NoContentExceptionTest.java
@@ -1,0 +1,28 @@
+package com.example.dearfam.common.exception;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NoContentExceptionTest {
+
+    @Test
+    void shouldReturnDefaultNoContentError() {
+        NoContentException noContentException = new NoContentException();
+
+        assertThat(noContentException.getErrorCode().defaultHttpStatus()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(noContentException.getErrorCode().name()).isEqualTo("NO_CONTENT");
+        assertThat(noContentException.getErrorCode().defaultMessage()).isEqualTo("요청한 데이터가 없습니다.");
+
+    }
+
+    @Test
+    void shouldReturnCustomMessageNoContentError() {
+        String message = "NoContentException 메시지 테스트";
+        NoContentException noContentException = new NoContentException(message);
+
+        assertThat(noContentException.getErrorCode().defaultMessage()).isEqualTo(message);
+    }
+
+}

--- a/src/test/java/com/example/dearfam/common/exception/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/example/dearfam/common/exception/handler/GlobalExceptionHandlerTest.java
@@ -1,0 +1,67 @@
+package com.example.dearfam.common.exception.handler;
+
+import com.example.dearfam.common.dto.exception.ApiResponseError;
+import com.example.dearfam.common.exception.CustomException;
+import com.example.dearfam.common.exception.NoContentException;
+import com.example.dearfam.common.exception.errorcode.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    void handleException_에러를반환해야함() {
+        // Exception 발생 시 에러 처리 되는지 확인하는 테스트 코드
+        TestErrorCode testErrorCode = new TestErrorCode();
+        CustomException exception = new CustomException(testErrorCode);
+
+        ResponseEntity<ApiResponseError> response = handler.handleException(exception);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().code()).isEqualTo("TEST_ERROR");
+        assertThat(response.getBody().message()).isEqualTo("테스트 에러 발생");
+    }
+
+    @Test
+    void handleNoContentException_204에러반환해야함() {
+        // 응답 본문이 필요없는 경우에 204 에러 객체를 반환하는지 확인하는 테스트 코드
+        NoContentException exception = new NoContentException();
+        ResponseEntity<ApiResponseError> response = handler.handleException(exception);
+        assertThat(response.getBody()).isNotNull();
+        System.out.println(response.getBody());
+    }
+
+    private static class TestErrorCode implements ErrorCode {
+        @Override
+        public String name() {
+            return "TEST_ERROR";
+        }
+
+        @Override
+        public HttpStatus defaultHttpStatus() {
+            return HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+
+        @Override
+        public String defaultMessage() {
+            return "테스트 에러 발생";
+        }
+
+        @Override
+        public RuntimeException defaultException() {
+            return new CustomException(this);
+        }
+
+        @Override
+        public RuntimeException defaultException(Throwable cause) {
+            return new CustomException(this, cause);
+        }
+    }
+}


### PR DESCRIPTION
* Exception Handler 에서 예외 객체가 잘 생성되는지 확인함.

* 테스트 중 ApiSimpleError 의 반복문 함수가 잘못되었음을 확인.
    * 예외 객체의 depth에 따라 반복문을 통해 리스트에 저장 후 반환하는 함수인데, currentCause를 새롭게 갱신하지 않아 테스트에서 depth 1의 예외 객체만 저장되는 것을 확인.
    * 갱신하는 코드를 추가 후, 테스트 코드 정상 작동 확인 완료함.