### PR TITLE
Family & 초대 링크 로직 구현

### DIFF
--- a/src/main/java/com/example/dearfam/DearfamApplication.java
+++ b/src/main/java/com/example/dearfam/DearfamApplication.java
@@ -3,9 +3,11 @@ package com.example.dearfam;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class DearfamApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/dearfam/common/jwt/auth/JwtService.java
+++ b/src/main/java/com/example/dearfam/common/jwt/auth/JwtService.java
@@ -4,6 +4,7 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.example.dearfam.common.dto.token.AuthTokenDto;
 import com.example.dearfam.common.dto.token.TokenDto;
+import com.example.dearfam.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -45,7 +46,7 @@ public class JwtService {
     public TokenDto getTokenDto() {
         TokenDto tokenDto = (TokenDto) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         if (tokenDto == null) {
-            throw new RuntimeException("TokenDto is null");
+            throw new CustomException("TokenDto is null");
         }
         return tokenDto;
     }

--- a/src/main/java/com/example/dearfam/domain/family/controller/FamilyController.java
+++ b/src/main/java/com/example/dearfam/domain/family/controller/FamilyController.java
@@ -4,6 +4,7 @@ import com.example.dearfam.common.dto.response.Response;
 import com.example.dearfam.common.jwt.auth.JwtService;
 import com.example.dearfam.domain.family.controller.request.FamilyNameRequest;
 import com.example.dearfam.domain.family.controller.request.UserFamilyRoleRequest;
+import com.example.dearfam.domain.family.controller.response.GetFamilyResponse;
 import com.example.dearfam.domain.family.controller.response.GetJoinedFamilyResponse;
 import com.example.dearfam.domain.family.dto.FamilyDto;
 import com.example.dearfam.domain.family.dto.InviteLinkResponse;
@@ -98,6 +99,37 @@ public class FamilyController {
         GetJoinedFamilyResponse joinedFamily = GetJoinedFamilyResponse.from(familyDto);
 
         return Response.data(joinedFamily);
+    }
+
+    @Operation(
+            summary = "가족 조회",
+            description = "로그인한 유저의 가족을 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "404", description = "USER_NOT_FOUND or FAMILY_NOT_FOUND"),
+                    @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
+            }
+    )
+    @GetMapping("/members")
+    public Response<GetFamilyResponse> getUserFamily() {
+        Long userId = jwtService.getTokenDto().getUserId();
+        GetFamilyResponse family = familyService.getUserFamily(userId);
+        return Response.data(family);
+    }
+
+    @Operation(
+            summary = "가족 ID를 통한 조회",
+            description = "가족 ID를 통해 가족을 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "404", description = "FAMILY_NOT_FOUND"),
+                    @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
+            }
+    )
+    @GetMapping("/members/{familyId}")
+    public Response<GetFamilyResponse> getUserFamilyByFamilyId(@PathVariable Long familyId) {
+        GetFamilyResponse family = familyService.getFamilyByFamilyId(familyId);
+        return Response.data(family);
     }
 
 }

--- a/src/main/java/com/example/dearfam/domain/family/controller/FamilyController.java
+++ b/src/main/java/com/example/dearfam/domain/family/controller/FamilyController.java
@@ -1,0 +1,41 @@
+package com.example.dearfam.domain.family.controller;
+
+import com.example.dearfam.common.dto.response.Response;
+import com.example.dearfam.common.jwt.auth.JwtService;
+import com.example.dearfam.domain.family.controller.request.FamilyNameRequest;
+import com.example.dearfam.domain.family.dto.FamilyDto;
+import com.example.dearfam.domain.family.service.FamilyService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/family")
+public class FamilyController {
+    private final FamilyService familyService;
+    private final JwtService jwtService;
+
+    @Operation(
+            summary = "가족 생성",
+            description = "현재 로그인한 유저가 새롭게 가족을 생성합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "404", description = "USER_NOT_FOUND"),
+                    @ApiResponse(responseCode = "409", description = "가족 이름 중복"),
+                    @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
+            }
+    )
+    @PostMapping
+    public Response<FamilyDto> createFamily(@Valid @RequestBody FamilyNameRequest request) {
+        Long userId = jwtService.getTokenDto().getUserId();
+        FamilyDto familyDto = familyService.createFamily(request.getFamilyName(), userId);
+        return Response.data(familyDto);
+    }
+
+}

--- a/src/main/java/com/example/dearfam/domain/family/controller/FamilyController.java
+++ b/src/main/java/com/example/dearfam/domain/family/controller/FamilyController.java
@@ -5,15 +5,13 @@ import com.example.dearfam.common.jwt.auth.JwtService;
 import com.example.dearfam.domain.family.controller.request.FamilyNameRequest;
 import com.example.dearfam.domain.family.controller.request.UserFamilyRoleRequest;
 import com.example.dearfam.domain.family.dto.FamilyDto;
+import com.example.dearfam.domain.family.dto.InviteLinkResponse;
 import com.example.dearfam.domain.family.service.FamilyService;
+import com.example.dearfam.domain.family.service.InviteService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
@@ -21,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class FamilyController {
     private final FamilyService familyService;
     private final JwtService jwtService;
+    private final InviteService inviteService;
 
     @Operation(
             summary = "가족 생성",
@@ -57,5 +56,23 @@ public class FamilyController {
         familyService.assignUserFamilyRole(userId, request.getFamilyRole());
 
         return Response.data(request.getFamilyRole() + " 역할을 설정했습니다.");
+    }
+
+    @Operation(
+            summary = "초대 링크 생성",
+            description = "로그인한 유저의 가족의 초대 링크를 생성합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "404", description = "유저 또는 가족 정보 없음"),
+                    @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
+            }
+    )
+    @PostMapping("/generate-link")
+    public Response<InviteLinkResponse> generateInviteLink() {
+        Long userId = jwtService.getTokenDto().getUserId();
+
+        InviteLinkResponse linkInfo = inviteService.generateInviteLink(userId);
+
+        return Response.data(linkInfo);
     }
 }

--- a/src/main/java/com/example/dearfam/domain/family/controller/FamilyController.java
+++ b/src/main/java/com/example/dearfam/domain/family/controller/FamilyController.java
@@ -4,6 +4,7 @@ import com.example.dearfam.common.dto.response.Response;
 import com.example.dearfam.common.jwt.auth.JwtService;
 import com.example.dearfam.domain.family.controller.request.FamilyNameRequest;
 import com.example.dearfam.domain.family.controller.request.UserFamilyRoleRequest;
+import com.example.dearfam.domain.family.controller.response.GetJoinedFamilyResponse;
 import com.example.dearfam.domain.family.dto.FamilyDto;
 import com.example.dearfam.domain.family.dto.InviteLinkResponse;
 import com.example.dearfam.domain.family.service.FamilyService;
@@ -12,6 +13,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -75,4 +77,27 @@ public class FamilyController {
 
         return Response.data(linkInfo);
     }
+
+    @Operation(
+            summary = "가족 참여",
+            description = "초대 링크로 가족에 참여하고, 참여한 가족을 보여줍니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "401", description = "유효하지 않은 코드"),
+                    @ApiResponse(responseCode = "404", description = "유저 또는 가족 정보 없음"),
+                    @ApiResponse(responseCode = "409", description = "이미 가족 존재함"),
+                    @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
+            }
+    )
+    @PostMapping("/join")
+    public Response<GetJoinedFamilyResponse> joinFamily(@RequestParam String code) {
+        Long userId = jwtService.getTokenDto().getUserId();
+
+        Long familyId = inviteService.validateInviteCodeAndReturnFamilyId(code); // 유효성 검증 & 예외 처리
+        FamilyDto familyDto =  familyService.addUserToFamily(userId, familyId);
+        GetJoinedFamilyResponse joinedFamily = GetJoinedFamilyResponse.from(familyDto);
+
+        return Response.data(joinedFamily);
+    }
+
 }

--- a/src/main/java/com/example/dearfam/domain/family/controller/FamilyController.java
+++ b/src/main/java/com/example/dearfam/domain/family/controller/FamilyController.java
@@ -3,6 +3,7 @@ package com.example.dearfam.domain.family.controller;
 import com.example.dearfam.common.dto.response.Response;
 import com.example.dearfam.common.jwt.auth.JwtService;
 import com.example.dearfam.domain.family.controller.request.FamilyNameRequest;
+import com.example.dearfam.domain.family.controller.request.UserFamilyRoleRequest;
 import com.example.dearfam.domain.family.dto.FamilyDto;
 import com.example.dearfam.domain.family.service.FamilyService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -38,4 +39,23 @@ public class FamilyController {
         return Response.data(familyDto);
     }
 
+    @Operation(
+            summary = "가족 내 역할 설정",
+            description = "클라이언트가 요청한 가족 역할을 유저 정보에 저장합니다. 값 : [FATHER, MOTHER, SON, DAUGHTER]",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청 (Enum 파싱 실패 등)"),
+                    @ApiResponse(responseCode = "404", description = "유저 또는 가족 정보 없음"),
+                    @ApiResponse(responseCode = "409", description = "역할 중복 또는 인원 제한 초과"),
+                    @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
+            }
+    )
+    @PostMapping("/role")
+    public Response<String> assignFamilyRole(@Valid @RequestBody UserFamilyRoleRequest request) {
+        Long userId = jwtService.getTokenDto().getUserId();
+
+        familyService.assignUserFamilyRole(userId, request.getFamilyRole());
+
+        return Response.data(request.getFamilyRole() + " 역할을 설정했습니다.");
+    }
 }

--- a/src/main/java/com/example/dearfam/domain/family/controller/FamilyController.java
+++ b/src/main/java/com/example/dearfam/domain/family/controller/FamilyController.java
@@ -7,7 +7,7 @@ import com.example.dearfam.domain.family.controller.request.UserFamilyRoleReques
 import com.example.dearfam.domain.family.controller.response.GetFamilyResponse;
 import com.example.dearfam.domain.family.controller.response.GetJoinedFamilyResponse;
 import com.example.dearfam.domain.family.dto.FamilyDto;
-import com.example.dearfam.domain.family.dto.InviteLinkResponse;
+import com.example.dearfam.domain.family.dto.InviteLinkDto;
 import com.example.dearfam.domain.family.service.FamilyService;
 import com.example.dearfam.domain.family.service.InviteService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -71,10 +71,10 @@ public class FamilyController {
             }
     )
     @PostMapping("/generate-link")
-    public Response<InviteLinkResponse> generateInviteLink() {
+    public Response<InviteLinkDto> generateInviteLink() {
         Long userId = jwtService.getTokenDto().getUserId();
 
-        InviteLinkResponse linkInfo = inviteService.generateInviteLink(userId);
+        InviteLinkDto linkInfo = inviteService.generateInviteLink(userId);
 
         return Response.data(linkInfo);
     }

--- a/src/main/java/com/example/dearfam/domain/family/controller/request/FamilyNameRequest.java
+++ b/src/main/java/com/example/dearfam/domain/family/controller/request/FamilyNameRequest.java
@@ -1,0 +1,12 @@
+package com.example.dearfam.domain.family.controller.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FamilyNameRequest {
+    @NotEmpty
+    private final String familyName;
+}

--- a/src/main/java/com/example/dearfam/domain/family/controller/request/UserFamilyRoleRequest.java
+++ b/src/main/java/com/example/dearfam/domain/family/controller/request/UserFamilyRoleRequest.java
@@ -1,0 +1,15 @@
+package com.example.dearfam.domain.family.controller.request;
+
+import com.example.dearfam.domain.users.entity.UserFamilyRole;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserFamilyRoleRequest {
+
+    @NotNull(message = "가족 역할은 필수입니다")
+    private UserFamilyRole familyRole;
+
+}

--- a/src/main/java/com/example/dearfam/domain/family/controller/response/GetFamilyResponse.java
+++ b/src/main/java/com/example/dearfam/domain/family/controller/response/GetFamilyResponse.java
@@ -1,0 +1,23 @@
+package com.example.dearfam.domain.family.controller.response;
+
+import com.example.dearfam.domain.family.dto.FamilyDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@AllArgsConstructor
+@Builder(access = PRIVATE)
+public class GetFamilyResponse {
+    private Long familyId;
+    private String familyName;
+
+    public static GetFamilyResponse from(FamilyDto familyDto) {
+        return GetFamilyResponse.builder()
+                .familyId(familyDto.getId())
+                .familyName(familyDto.getFamilyName())
+                .build();
+    }
+}

--- a/src/main/java/com/example/dearfam/domain/family/controller/response/GetFamilyResponse.java
+++ b/src/main/java/com/example/dearfam/domain/family/controller/response/GetFamilyResponse.java
@@ -1,9 +1,12 @@
 package com.example.dearfam.domain.family.controller.response;
 
 import com.example.dearfam.domain.family.dto.FamilyDto;
+import com.example.dearfam.domain.users.dto.FamilyMemberDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
 
 import static lombok.AccessLevel.PRIVATE;
 
@@ -13,11 +16,13 @@ import static lombok.AccessLevel.PRIVATE;
 public class GetFamilyResponse {
     private Long familyId;
     private String familyName;
+    private List<FamilyMemberDto> familyMembers;
 
-    public static GetFamilyResponse from(FamilyDto familyDto) {
+    public static GetFamilyResponse from(FamilyDto familyDto, List<FamilyMemberDto> familyMembers) {
         return GetFamilyResponse.builder()
                 .familyId(familyDto.getId())
                 .familyName(familyDto.getFamilyName())
+                .familyMembers(familyMembers)
                 .build();
     }
 }

--- a/src/main/java/com/example/dearfam/domain/family/controller/response/GetJoinedFamilyResponse.java
+++ b/src/main/java/com/example/dearfam/domain/family/controller/response/GetJoinedFamilyResponse.java
@@ -1,0 +1,23 @@
+package com.example.dearfam.domain.family.controller.response;
+
+import com.example.dearfam.domain.family.dto.FamilyDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@AllArgsConstructor
+@Builder(access = PRIVATE)
+public class GetJoinedFamilyResponse {
+    private Long joinedFamilyId;
+    private String joinedFamilyName;
+
+    public static GetJoinedFamilyResponse from(FamilyDto familyDto) {
+        return GetJoinedFamilyResponse.builder()
+                .joinedFamilyId(familyDto.getId())
+                .joinedFamilyName(familyDto.getFamilyName())
+                .build();
+    }
+}

--- a/src/main/java/com/example/dearfam/domain/family/dto/FamilyDto.java
+++ b/src/main/java/com/example/dearfam/domain/family/dto/FamilyDto.java
@@ -15,6 +15,8 @@ import java.util.stream.Collectors;
 public class FamilyDto {
     private Long id;
     private String familyName;
+    private Integer parentCount;
+    private Integer childCount;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -22,6 +24,8 @@ public class FamilyDto {
         return FamilyDto.builder()
                 .id(family.getId())
                 .familyName(family.getFamilyName())
+                .parentCount(family.getParentCount())
+                .childCount(family.getChildCount())
                 .createdAt(family.getCreatedAt())
                 .updatedAt(family.getUpdatedAt())
                 .build();

--- a/src/main/java/com/example/dearfam/domain/family/dto/FamilyDto.java
+++ b/src/main/java/com/example/dearfam/domain/family/dto/FamilyDto.java
@@ -1,0 +1,35 @@
+package com.example.dearfam.domain.family.dto;
+
+import com.example.dearfam.domain.family.entity.Family;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class FamilyDto {
+    private Long id;
+    private String familyName;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static FamilyDto from(Family family) {
+        return FamilyDto.builder()
+                .id(family.getId())
+                .familyName(family.getFamilyName())
+                .createdAt(family.getCreatedAt())
+                .updatedAt(family.getUpdatedAt())
+                .build();
+    }
+
+    public static List<FamilyDto> from(List<Family> families) {
+        return families.stream()
+                .map(FamilyDto::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/dearfam/domain/family/dto/InviteLinkDto.java
+++ b/src/main/java/com/example/dearfam/domain/family/dto/InviteLinkDto.java
@@ -11,13 +11,13 @@ import static lombok.AccessLevel.PRIVATE;
 @Getter
 @AllArgsConstructor
 @Builder(access = PRIVATE)
-public class InviteLinkResponse {
+public class InviteLinkDto {
     private String link;
     private String code;
     private LocalDateTime expiresAt;
 
-    public static InviteLinkResponse from(String link, String code, LocalDateTime expiresAt) {
-        return InviteLinkResponse.builder()
+    public static InviteLinkDto from(String link, String code, LocalDateTime expiresAt) {
+        return InviteLinkDto.builder()
                 .link(link)
                 .code(code)
                 .expiresAt(expiresAt)

--- a/src/main/java/com/example/dearfam/domain/family/dto/InviteLinkResponse.java
+++ b/src/main/java/com/example/dearfam/domain/family/dto/InviteLinkResponse.java
@@ -1,0 +1,26 @@
+package com.example.dearfam.domain.family.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@AllArgsConstructor
+@Builder(access = PRIVATE)
+public class InviteLinkResponse {
+    private String link;
+    private String code;
+    private LocalDateTime expiresAt;
+
+    public static InviteLinkResponse from(String link, String code, LocalDateTime expiresAt) {
+        return InviteLinkResponse.builder()
+                .link(link)
+                .code(code)
+                .expiresAt(expiresAt)
+                .build();
+    }
+}

--- a/src/main/java/com/example/dearfam/domain/family/entity/Family.java
+++ b/src/main/java/com/example/dearfam/domain/family/entity/Family.java
@@ -23,11 +23,18 @@ public class Family extends BaseTimeEntity {
     @Column(name = "family_name", nullable = false, length = 20)
     private String familyName;
 
+    @Column(name = "parent_count")
+    private Integer parentCount;
+
+    @Column(name = "child_count")
+    private Integer childCount;
+
     @Builder
-    public Family(Long id, String familyName) {
+    public Family(Long id, String familyName, Integer parentCount, Integer childCount) {
         this.id = id;
         this.familyName = familyName;
+        this.parentCount = parentCount != null ? parentCount : 0;
+        this.childCount = childCount != null ? childCount : 0;
     }
-
 
 }

--- a/src/main/java/com/example/dearfam/domain/family/entity/Family.java
+++ b/src/main/java/com/example/dearfam/domain/family/entity/Family.java
@@ -1,0 +1,33 @@
+package com.example.dearfam.domain.family.entity;
+
+import com.example.dearfam.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "family")
+public class Family extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "family_id")
+    private Long id;
+
+    @Column(name = "family_name", nullable = false, length = 20)
+    private String familyName;
+
+    @Builder
+    public Family(Long id, String familyName) {
+        this.id = id;
+        this.familyName = familyName;
+    }
+
+
+}

--- a/src/main/java/com/example/dearfam/domain/family/exception/FamilyErrorCode.java
+++ b/src/main/java/com/example/dearfam/domain/family/exception/FamilyErrorCode.java
@@ -1,0 +1,36 @@
+package com.example.dearfam.domain.family.exception;
+
+import com.example.dearfam.common.exception.errorcode.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum FamilyErrorCode implements ErrorCode {
+    FAMILY_NOT_REGISTERED("가족이 등록되어 있지 않습니다.", HttpStatus.NOT_FOUND),
+    FAMILY_NOT_FOUND("가족을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    FAMILY_ALREADY_EXISTS("이미 가족이 존재합니다.", HttpStatus.CONFLICT),
+    DEFAULT("가족 관련 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final String message;
+    private final HttpStatus status;
+
+    @Override
+    public HttpStatus defaultHttpStatus() {
+        return status;
+    }
+
+    @Override
+    public String defaultMessage() {
+        return message;
+    }
+
+    @Override
+    public FamilyException defaultException() {
+        return new FamilyException(this);
+    }
+
+    @Override
+    public FamilyException defaultException(Throwable cause) {
+        return new FamilyException(this, cause);
+    }
+}

--- a/src/main/java/com/example/dearfam/domain/family/exception/FamilyErrorCode.java
+++ b/src/main/java/com/example/dearfam/domain/family/exception/FamilyErrorCode.java
@@ -9,6 +9,10 @@ public enum FamilyErrorCode implements ErrorCode {
     FAMILY_NOT_REGISTERED("가족이 등록되어 있지 않습니다.", HttpStatus.NOT_FOUND),
     FAMILY_NOT_FOUND("가족을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     FAMILY_ALREADY_EXISTS("이미 가족이 존재합니다.", HttpStatus.CONFLICT),
+    ROLE_ALREADY_ASSIGNED("이미 사용 중인 역할입니다.", HttpStatus.CONFLICT),
+    INVALID_FAMILY_NAME("유효하지 않은 가족 이름입니다.", HttpStatus.BAD_REQUEST),
+    PARENT_LIMIT_EXCEEDED("부모는 최대 2명까지 설정할 수 있습니다.", HttpStatus.BAD_REQUEST),
+    CHILD_LIMIT_EXCEEDED("자녀는 최대 5명까지 설정할 수 있습니다.", HttpStatus.BAD_REQUEST),
     DEFAULT("가족 관련 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String message;

--- a/src/main/java/com/example/dearfam/domain/family/exception/FamilyException.java
+++ b/src/main/java/com/example/dearfam/domain/family/exception/FamilyException.java
@@ -1,0 +1,28 @@
+package com.example.dearfam.domain.family.exception;
+
+import com.example.dearfam.common.exception.CustomException;
+import com.example.dearfam.common.exception.errorcode.ErrorCode;
+
+public class FamilyException extends CustomException {
+
+    public FamilyException() {
+        super();
+    }
+
+    public FamilyException(String message) {
+        super(message);
+    }
+
+    public FamilyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public FamilyException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public FamilyException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
+
+}

--- a/src/main/java/com/example/dearfam/domain/family/exception/InviteErrorCode.java
+++ b/src/main/java/com/example/dearfam/domain/family/exception/InviteErrorCode.java
@@ -1,0 +1,36 @@
+package com.example.dearfam.domain.family.exception;
+
+import com.example.dearfam.common.exception.CustomException;
+import com.example.dearfam.common.exception.errorcode.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum InviteErrorCode implements ErrorCode {
+    INVALID_INVITE_CODE("유효하지 않은 초대 코드입니다.", HttpStatus.BAD_REQUEST),
+    INVITE_CODE_EXPIRED("초대 코드가 만료되었습니다.", HttpStatus.GONE);
+
+
+    private final String message;
+    private final HttpStatus status;
+
+    @Override
+    public HttpStatus defaultHttpStatus() {
+        return status;
+    }
+
+    @Override
+    public String defaultMessage() {
+        return message;
+    }
+
+    @Override
+    public CustomException defaultException() {
+        return new InviteException(this);
+    }
+
+    @Override
+    public CustomException defaultException(Throwable cause) {
+        return new InviteException(this, cause);
+    }
+}

--- a/src/main/java/com/example/dearfam/domain/family/exception/InviteException.java
+++ b/src/main/java/com/example/dearfam/domain/family/exception/InviteException.java
@@ -1,0 +1,28 @@
+package com.example.dearfam.domain.family.exception;
+
+import com.example.dearfam.common.exception.CustomException;
+import com.example.dearfam.common.exception.errorcode.ErrorCode;
+
+public class InviteException extends CustomException {
+
+    public InviteException() {
+        super();
+    }
+
+    public InviteException(String message) {
+        super(message);
+    }
+
+    public InviteException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InviteException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public InviteException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
+
+}

--- a/src/main/java/com/example/dearfam/domain/family/invite/InviteLinkCleaner.java
+++ b/src/main/java/com/example/dearfam/domain/family/invite/InviteLinkCleaner.java
@@ -1,0 +1,17 @@
+package com.example.dearfam.domain.family.invite;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class InviteLinkCleaner {
+    private final InviteLinkStore inviteLinkStore;
+
+    @Scheduled(fixedRate = 60000) // 1분마다 실행
+    public void cleanExpiredCode() {
+//        inviteLinkStore.printAllInviteLinks();
+        inviteLinkStore.removeExpiredCode();
+    }
+}

--- a/src/main/java/com/example/dearfam/domain/family/invite/InviteLinkInfo.java
+++ b/src/main/java/com/example/dearfam/domain/family/invite/InviteLinkInfo.java
@@ -1,0 +1,17 @@
+package com.example.dearfam.domain.family.invite;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class InviteLinkInfo {
+    private Long familyId;
+    private LocalDateTime expireAt;
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expireAt);
+    }
+}

--- a/src/main/java/com/example/dearfam/domain/family/invite/InviteLinkStore.java
+++ b/src/main/java/com/example/dearfam/domain/family/invite/InviteLinkStore.java
@@ -1,0 +1,39 @@
+package com.example.dearfam.domain.family.invite;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class InviteLinkStore {
+    private final Map<String, InviteLinkInfo> inviteLinkMap = new ConcurrentHashMap<>();
+
+    public void addCode(String code, Long familyId, LocalDateTime expiresAt) {
+        InviteLinkInfo linkInfo = new InviteLinkInfo(familyId, expiresAt);
+        inviteLinkMap.put(code,linkInfo);
+    }
+
+    // 이 함수로 함수의 유효성을 검사함. 코드의 정보가 null이거나 만료되었을 때, null값을 리턴함.
+    // 아직 유효하다면 familyId를 리턴함.
+    public Long getFamilyId(String code) {
+        InviteLinkInfo info = inviteLinkMap.get(code);
+        if (info == null || info.isExpired()) {
+            inviteLinkMap.remove(code);
+            return null;
+        }
+        return info.getFamilyId();
+    }
+
+    public void removeExpiredCode() {
+        inviteLinkMap.entrySet().removeIf(entry -> entry.getValue().isExpired());
+    }
+
+//    public void printAllInviteLinks() {
+//        inviteLinkMap.forEach((code, info) -> {
+//            System.out.println("Code: " + code + ", FamilyId: " + info.getFamilyId() + ", ExpiresAt: " + info.getExpireAt());
+//        });
+//    }
+
+}

--- a/src/main/java/com/example/dearfam/domain/family/repository/FamilyRepository.java
+++ b/src/main/java/com/example/dearfam/domain/family/repository/FamilyRepository.java
@@ -1,0 +1,9 @@
+package com.example.dearfam.domain.family.repository;
+
+import com.example.dearfam.domain.family.entity.Family;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FamilyRepository extends JpaRepository<Family, Long> {
+}

--- a/src/main/java/com/example/dearfam/domain/family/service/FamilyService.java
+++ b/src/main/java/com/example/dearfam/domain/family/service/FamilyService.java
@@ -4,6 +4,7 @@ import com.example.dearfam.domain.family.dto.FamilyDto;
 import com.example.dearfam.domain.family.entity.Family;
 import com.example.dearfam.domain.family.exception.FamilyErrorCode;
 import com.example.dearfam.domain.family.repository.FamilyRepository;
+import com.example.dearfam.domain.users.entity.UserFamilyRole;
 import com.example.dearfam.domain.users.entity.Users;
 import com.example.dearfam.domain.users.exception.UsersErrorCode;
 import com.example.dearfam.domain.users.repository.UsersRepository;
@@ -18,7 +19,7 @@ public class FamilyService {
     private final UsersRepository usersRepository;
 
     @Transactional
-    public FamilyDto createFamily(String FamilyName, Long userId) {
+    public FamilyDto createFamily(String familyName, Long userId) {
         // 카카오 로그인 이후임
         // 가족 이름 작성 후 family 디비에 저장 -> 가족 id 현재 로그인한 유저 정보에 set
         Users user = usersRepository.findById(userId)
@@ -28,8 +29,12 @@ public class FamilyService {
             throw FamilyErrorCode.FAMILY_ALREADY_EXISTS.defaultException();
         }
 
+        if(familyName == null || familyName.isEmpty()) {
+            throw FamilyErrorCode.INVALID_FAMILY_NAME.defaultException();
+        }
+
         Family family = Family.builder()
-                .familyName(FamilyName)
+                .familyName(familyName)
                 .build();
         familyRepository.save(family);
 
@@ -39,6 +44,40 @@ public class FamilyService {
         usersRepository.save(user);
 
         return FamilyDto.from(family);
+    }
+
+    @Transactional
+    public void assignUserFamilyRole(Long userId, UserFamilyRole userFamilyRole) {
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(UsersErrorCode.USER_NOT_FOUND::defaultException);
+
+        Family family = user.getFamily();
+        if (family == null) {
+            throw FamilyErrorCode.FAMILY_NOT_FOUND.defaultException();
+        }
+
+        // 부모 역할 제한 -> 아빠, 엄마 한 명씩으로 제한
+        if (userFamilyRole.isParent()) {
+            boolean fatherExists = userFamilyRole == UserFamilyRole.FATHER && usersRepository.existsByFamilyAndUserFamilyRole(family, UserFamilyRole.FATHER);
+            boolean motherExists = userFamilyRole == UserFamilyRole.MOTHER && usersRepository.existsByFamilyAndUserFamilyRole(family, UserFamilyRole.MOTHER);
+
+            if (fatherExists || motherExists) {
+                throw FamilyErrorCode.PARENT_LIMIT_EXCEEDED.defaultException();
+            }
+            family.setParentCount(family.getParentCount() + 1);
+        }
+
+        // 자녀 수 5명으로 제한
+        if (userFamilyRole.isChild()) {
+            if (family.getChildCount() >= 5) {
+                throw FamilyErrorCode.CHILD_LIMIT_EXCEEDED.defaultException();
+            }
+            family.setChildCount(family.getChildCount() + 1);
+        }
+
+        user.setUserFamilyRole(userFamilyRole);
+        usersRepository.save(user);
+        familyRepository.save(family);
     }
 
 }

--- a/src/main/java/com/example/dearfam/domain/family/service/FamilyService.java
+++ b/src/main/java/com/example/dearfam/domain/family/service/FamilyService.java
@@ -1,9 +1,12 @@
 package com.example.dearfam.domain.family.service;
 
+import com.example.dearfam.common.entity.BaseTimeEntity;
+import com.example.dearfam.domain.family.controller.response.GetFamilyResponse;
 import com.example.dearfam.domain.family.dto.FamilyDto;
 import com.example.dearfam.domain.family.entity.Family;
 import com.example.dearfam.domain.family.exception.FamilyErrorCode;
 import com.example.dearfam.domain.family.repository.FamilyRepository;
+import com.example.dearfam.domain.users.dto.FamilyMemberDto;
 import com.example.dearfam.domain.users.entity.UserFamilyRole;
 import com.example.dearfam.domain.users.entity.Users;
 import com.example.dearfam.domain.users.exception.UsersErrorCode;
@@ -11,6 +14,9 @@ import com.example.dearfam.domain.users.repository.UsersRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -97,5 +103,55 @@ public class FamilyService {
         return FamilyDto.from(family);
     }
 
+
+    @Transactional
+    public GetFamilyResponse getUserFamily(Long userId) {
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(UsersErrorCode.USER_NOT_FOUND::defaultException);
+
+        Family family = user.getFamily();
+        if (family == null) {
+            throw FamilyErrorCode.FAMILY_NOT_FOUND.defaultException();
+        }
+
+        FamilyDto familyDto = FamilyDto.from(family);
+
+        List<FamilyMemberDto> familyMembers = getMembersByFamily(family);
+
+        return GetFamilyResponse.from(familyDto, familyMembers);
+    }
+
+    @Transactional
+    public GetFamilyResponse getFamilyByFamilyId(Long familyId) {
+        Family family = familyRepository.findById(familyId)
+                .orElseThrow(FamilyErrorCode.FAMILY_NOT_FOUND::defaultException);
+
+        FamilyDto familyDto = FamilyDto.from(family);
+
+        List<FamilyMemberDto> familyMembers = getMembersByFamily(family);
+
+        return GetFamilyResponse.from(familyDto, familyMembers);
+    }
+
+
+    // 아빠, 엄마, 추가된 자녀 순서대로 가족 구성원 리스트를 뽑아내는 함수
+    private List<FamilyMemberDto> getMembersByFamily(Family family) {
+        List<Users> members = usersRepository.findAllByFamily(family);
+
+        return members.stream()
+                .sorted(Comparator.comparing((Users u) -> {
+                    UserFamilyRole userFamilyRole = u.getUserFamilyRole();
+                    if (userFamilyRole == null) return 3; // 제일 마지막
+                    if (userFamilyRole == UserFamilyRole.FATHER) return 0;
+                    if (userFamilyRole == UserFamilyRole.MOTHER) return 1;
+                    return 2;
+                }).thenComparing(BaseTimeEntity::getCreatedAt))
+                .map(member -> FamilyMemberDto.from(
+                        member.getId(),
+                        member.getUserNickname(),
+                        member.getUserFamilyRole()
+                ))
+                .toList();
+    }
 
 }

--- a/src/main/java/com/example/dearfam/domain/family/service/FamilyService.java
+++ b/src/main/java/com/example/dearfam/domain/family/service/FamilyService.java
@@ -80,4 +80,22 @@ public class FamilyService {
         familyRepository.save(family);
     }
 
+    @Transactional
+    public FamilyDto addUserToFamily(Long userId, Long familyId) {
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(UsersErrorCode.USER_NOT_FOUND::defaultException);
+
+        if (user.getFamily() != null) {
+            throw FamilyErrorCode.FAMILY_ALREADY_EXISTS.defaultException();
+        }
+
+        Family family = familyRepository.findById(familyId)
+                .orElseThrow(FamilyErrorCode.FAMILY_NOT_FOUND::defaultException);
+
+        user.setFamily(family);
+        usersRepository.save(user);
+        return FamilyDto.from(family);
+    }
+
+
 }

--- a/src/main/java/com/example/dearfam/domain/family/service/FamilyService.java
+++ b/src/main/java/com/example/dearfam/domain/family/service/FamilyService.java
@@ -1,0 +1,44 @@
+package com.example.dearfam.domain.family.service;
+
+import com.example.dearfam.domain.family.dto.FamilyDto;
+import com.example.dearfam.domain.family.entity.Family;
+import com.example.dearfam.domain.family.exception.FamilyErrorCode;
+import com.example.dearfam.domain.family.repository.FamilyRepository;
+import com.example.dearfam.domain.users.entity.Users;
+import com.example.dearfam.domain.users.exception.UsersErrorCode;
+import com.example.dearfam.domain.users.repository.UsersRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class FamilyService {
+    private final FamilyRepository familyRepository;
+    private final UsersRepository usersRepository;
+
+    @Transactional
+    public FamilyDto createFamily(String FamilyName, Long userId) {
+        // 카카오 로그인 이후임
+        // 가족 이름 작성 후 family 디비에 저장 -> 가족 id 현재 로그인한 유저 정보에 set
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(UsersErrorCode.USER_NOT_FOUND::defaultException);
+
+        if (user.getFamily() != null) {
+            throw FamilyErrorCode.FAMILY_ALREADY_EXISTS.defaultException();
+        }
+
+        Family family = Family.builder()
+                .familyName(FamilyName)
+                .build();
+        familyRepository.save(family);
+
+
+        user.setIsFamilyRoomManager(true);
+        user.setFamily(family);
+        usersRepository.save(user);
+
+        return FamilyDto.from(family);
+    }
+
+}

--- a/src/main/java/com/example/dearfam/domain/family/service/InviteService.java
+++ b/src/main/java/com/example/dearfam/domain/family/service/InviteService.java
@@ -1,6 +1,6 @@
 package com.example.dearfam.domain.family.service;
 
-import com.example.dearfam.domain.family.dto.InviteLinkResponse;
+import com.example.dearfam.domain.family.dto.InviteLinkDto;
 import com.example.dearfam.domain.family.exception.FamilyErrorCode;
 import com.example.dearfam.domain.family.exception.InviteErrorCode;
 import com.example.dearfam.domain.family.invite.InviteLinkStore;
@@ -24,7 +24,7 @@ public class InviteService {
     @Value("${invite.base-url}")
     private String inviteBaseUrl;
 
-    public InviteLinkResponse generateInviteLink(Long userId) {
+    public InviteLinkDto generateInviteLink(Long userId) {
         Users user = usersRepository.findById(userId)
                 .orElseThrow(UsersErrorCode.USER_NOT_FOUND::defaultException);
 
@@ -43,7 +43,7 @@ public class InviteService {
 
         String link = inviteBaseUrl + "?code=" + code;
 
-        return InviteLinkResponse.from(link, code, expiresAt);
+        return InviteLinkDto.from(link, code, expiresAt);
     }
 
     public Long validateInviteCodeAndReturnFamilyId(String inviteCode) {

--- a/src/main/java/com/example/dearfam/domain/family/service/InviteService.java
+++ b/src/main/java/com/example/dearfam/domain/family/service/InviteService.java
@@ -1,0 +1,57 @@
+package com.example.dearfam.domain.family.service;
+
+import com.example.dearfam.domain.family.dto.InviteLinkResponse;
+import com.example.dearfam.domain.family.exception.FamilyErrorCode;
+import com.example.dearfam.domain.family.exception.InviteErrorCode;
+import com.example.dearfam.domain.family.invite.InviteLinkStore;
+import com.example.dearfam.domain.users.entity.Users;
+import com.example.dearfam.domain.users.exception.UsersErrorCode;
+import com.example.dearfam.domain.users.repository.UsersRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Service
+public class InviteService {
+    private final UsersRepository usersRepository;
+    private final InviteLinkStore inviteLinkStore;
+
+    @Value("${invite.base-url}")
+    private String inviteBaseUrl;
+
+    public InviteLinkResponse generateInviteLink(Long userId) {
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(UsersErrorCode.USER_NOT_FOUND::defaultException);
+
+        if (user.getFamily() == null) {
+            throw FamilyErrorCode.FAMILY_NOT_FOUND.defaultException();
+        }
+
+        Long familyId = user.getFamily().getId();
+
+        String code = UUID.randomUUID().toString().substring(0, 6).toUpperCase();
+        // 유효기간 1일
+        LocalDateTime expiresAt = LocalDateTime.now().plus(Duration.ofDays(1));
+        // 테스트용
+//        LocalDateTime expiresAt = LocalDateTime.now().plus(Duration.ofMinutes(1));
+        inviteLinkStore.addCode(code, familyId, expiresAt);
+
+        String link = inviteBaseUrl + "?code=" + code;
+
+        return InviteLinkResponse.from(link, code, expiresAt);
+    }
+
+    public Long validateInviteCodeAndReturnFamilyId(String inviteCode) {
+        Long familyId = inviteLinkStore.getFamilyId(inviteCode);
+        if (familyId == null) {
+            throw InviteErrorCode.INVALID_INVITE_CODE.defaultException();
+        }
+        return familyId;
+    }
+
+}

--- a/src/main/java/com/example/dearfam/domain/users/controller/UsersController.java
+++ b/src/main/java/com/example/dearfam/domain/users/controller/UsersController.java
@@ -2,7 +2,6 @@ package com.example.dearfam.domain.users.controller;
 
 import com.example.dearfam.common.dto.response.Response;
 import com.example.dearfam.common.jwt.auth.JwtService;
-import com.example.dearfam.domain.family.controller.response.GetFamilyResponse;
 import com.example.dearfam.domain.users.controller.request.UserNicknameRequest;
 import com.example.dearfam.domain.users.controller.response.GetUserResponse;
 import com.example.dearfam.domain.users.dto.UsersDto;
@@ -67,22 +66,6 @@ public class UsersController {
         Long userId = jwtService.getTokenDto().getUserId();
         usersService.updateUserNickname(userId, userNicknameRequest.getNickname());
         return Response.data("User Nickname Updated");
-    }
-
-    @Operation(
-            summary = "가족 조회",
-            description = "로그인한 유저의 가족을 조회합니다.",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "OK"),
-                    @ApiResponse(responseCode = "404", description = "USER_NOT_FOUND or FAMILY_NOT_FOUND"),
-                    @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
-            }
-    )
-    @GetMapping("/family")
-    public Response<GetFamilyResponse> getUserFamily() {
-        Long userId = jwtService.getTokenDto().getUserId();
-        GetFamilyResponse family = usersService.getUserFamily(userId);
-        return Response.data(family);
     }
 
 }

--- a/src/main/java/com/example/dearfam/domain/users/controller/UsersController.java
+++ b/src/main/java/com/example/dearfam/domain/users/controller/UsersController.java
@@ -2,17 +2,16 @@ package com.example.dearfam.domain.users.controller;
 
 import com.example.dearfam.common.dto.response.Response;
 import com.example.dearfam.common.jwt.auth.JwtService;
+import com.example.dearfam.domain.family.controller.response.GetFamilyResponse;
 import com.example.dearfam.domain.users.controller.request.UserNicknameRequest;
 import com.example.dearfam.domain.users.controller.response.GetUserResponse;
 import com.example.dearfam.domain.users.dto.UsersDto;
 import com.example.dearfam.domain.users.service.UsersService;
-import com.mysql.cj.x.protobuf.Mysqlx;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -66,9 +65,24 @@ public class UsersController {
     @PutMapping("/nickname")
     public Response<String> updateUserNickname(@Valid @RequestBody UserNicknameRequest userNicknameRequest) {
         Long userId = jwtService.getTokenDto().getUserId();
-
         usersService.updateUserNickname(userId, userNicknameRequest.getNickname());
         return Response.data("User Nickname Updated");
+    }
+
+    @Operation(
+            summary = "가족 조회",
+            description = "로그인한 유저의 가족을 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "404", description = "USER_NOT_FOUND or FAMILY_NOT_FOUND"),
+                    @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
+            }
+    )
+    @GetMapping("/family")
+    public Response<GetFamilyResponse> getUserFamily() {
+        Long userId = jwtService.getTokenDto().getUserId();
+        GetFamilyResponse family = usersService.getUserFamily(userId);
+        return Response.data(family);
     }
 
 }

--- a/src/main/java/com/example/dearfam/domain/users/controller/response/GetUserResponse.java
+++ b/src/main/java/com/example/dearfam/domain/users/controller/response/GetUserResponse.java
@@ -16,6 +16,7 @@ public class GetUserResponse {
     private Long familyId;
     private String userNickName;
     private String userRole;
+    private UserFamilyRole userFamilyRole;
     private Boolean isFamilyRoomManager;
     private String profileImage;
 

--- a/src/main/java/com/example/dearfam/domain/users/controller/response/GetUserResponse.java
+++ b/src/main/java/com/example/dearfam/domain/users/controller/response/GetUserResponse.java
@@ -1,7 +1,7 @@
 package com.example.dearfam.domain.users.controller.response;
 
 import com.example.dearfam.domain.users.dto.UsersDto;
-import com.example.dearfam.domain.users.entity.Users;
+import com.example.dearfam.domain.users.entity.UserFamilyRole;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,15 +13,16 @@ import static lombok.AccessLevel.PRIVATE;
 @Builder(access = PRIVATE)
 public class GetUserResponse {
     private Long id;
+    private Long familyId;
     private String userNickName;
     private String userRole;
-    private String userFamilyRole;
     private Boolean isFamilyRoomManager;
     private String profileImage;
 
     public static GetUserResponse from(UsersDto usersDto) {
         return GetUserResponse.builder()
                 .id(usersDto.getId())
+                .familyId(usersDto.getFamily() != null ? usersDto.getFamily().getId() : null)
                 .userNickName(usersDto.getUserNickName())
                 .userRole(usersDto.getUserRole())
                 .userFamilyRole(usersDto.getUserFamilyRole())

--- a/src/main/java/com/example/dearfam/domain/users/dto/FamilyMemberDto.java
+++ b/src/main/java/com/example/dearfam/domain/users/dto/FamilyMemberDto.java
@@ -1,0 +1,38 @@
+package com.example.dearfam.domain.users.dto;
+
+import com.example.dearfam.domain.users.entity.UserFamilyRole;
+import com.example.dearfam.domain.users.entity.Users;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+@Builder(access = AccessLevel.PRIVATE)
+public class FamilyMemberDto {
+    private Long userId;
+    private String userNickname;
+    private UserFamilyRole userFamilyRole;
+
+    public static FamilyMemberDto from(Long userId, String userNickname, UserFamilyRole userFamilyRole) {
+        return FamilyMemberDto.builder()
+                .userId(userId)
+                .userNickname(userNickname)
+                .userFamilyRole(userFamilyRole)
+                .build();
+    }
+
+    public static List<FamilyMemberDto> from(List<Users> users) {
+        return users.stream()
+                .map(user -> FamilyMemberDto.from(
+                        user.getId(),
+                        user.getUserNickname(),
+                        user.getUserFamilyRole()
+                ))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/dearfam/domain/users/dto/UsersDto.java
+++ b/src/main/java/com/example/dearfam/domain/users/dto/UsersDto.java
@@ -1,6 +1,7 @@
 package com.example.dearfam.domain.users.dto;
 
 import com.example.dearfam.domain.family.entity.Family;
+import com.example.dearfam.domain.users.entity.UserFamilyRole;
 import com.example.dearfam.domain.users.entity.Users;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,6 +19,7 @@ public class UsersDto {
     private Family family;
     private String userNickName;
     private String userRole;
+    private UserFamilyRole userFamilyRole;
     private Boolean isFamilyRoomManager;
     private String profileImage;
     private LocalDateTime createdAt;

--- a/src/main/java/com/example/dearfam/domain/users/dto/UsersDto.java
+++ b/src/main/java/com/example/dearfam/domain/users/dto/UsersDto.java
@@ -1,10 +1,12 @@
 package com.example.dearfam.domain.users.dto;
 
+import com.example.dearfam.domain.family.entity.Family;
 import com.example.dearfam.domain.users.entity.Users;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -13,20 +15,25 @@ import java.util.stream.Collectors;
 @Builder
 public class UsersDto {
     private Long id;
+    private Family family;
     private String userNickName;
     private String userRole;
-    private String userFamilyRole;
     private Boolean isFamilyRoomManager;
     private String profileImage;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
     public static UsersDto from(Users user) {
         return UsersDto.builder()
                 .id(user.getId())
+                .family(user.getFamily())
                 .userNickName(user.getUserNickname())
                 .userRole(user.getUserRole())
                 .userFamilyRole(user.getUserFamilyRole())
                 .isFamilyRoomManager(user.getIsFamilyRoomManager())
                 .profileImage(user.getProfileImage())
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
                 .build();
     }
 

--- a/src/main/java/com/example/dearfam/domain/users/entity/UserFamilyRole.java
+++ b/src/main/java/com/example/dearfam/domain/users/entity/UserFamilyRole.java
@@ -1,0 +1,21 @@
+package com.example.dearfam.domain.users.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "가족 내 역할", example = "FATHER", allowableValues = {"MOTHER", "FATHER", "SON", "DAUGHTER"})
+public enum UserFamilyRole {
+    FATHER,
+    MOTHER,
+    SON,
+    DAUGHTER;
+
+    public boolean isParent() {
+        return this == MOTHER || this == FATHER;
+    }
+
+    public boolean isChild() {
+        return this == SON || this == DAUGHTER;
+    }
+}

--- a/src/main/java/com/example/dearfam/domain/users/entity/Users.java
+++ b/src/main/java/com/example/dearfam/domain/users/entity/Users.java
@@ -27,6 +27,7 @@ public class Users extends BaseTimeEntity {  // BaseTimeEntity에 생성일(crea
     @Column(name = "user_role", nullable = false)
     private String userRole;
 
+    // TODO : API 명세서 수정
     @Enumerated(EnumType.STRING)
     @Column(name = "user_family_role")
     private UserFamilyRole userFamilyRole;

--- a/src/main/java/com/example/dearfam/domain/users/entity/Users.java
+++ b/src/main/java/com/example/dearfam/domain/users/entity/Users.java
@@ -14,7 +14,6 @@ public class Users extends BaseTimeEntity {  // BaseTimeEntity에 생성일(crea
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "user_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -27,6 +26,9 @@ public class Users extends BaseTimeEntity {  // BaseTimeEntity에 생성일(crea
     @Column(name = "user_role", nullable = false)
     private String userRole;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "user_family_role")
+    private UserFamilyRole userFamilyRole;
 
     @Column(name = "is_family_room_manager")
     private Boolean isFamilyRoomManager;
@@ -34,7 +36,6 @@ public class Users extends BaseTimeEntity {  // BaseTimeEntity에 생성일(crea
     @Column(name = "profile_image")
     private String profileImage;
 
-    @Column(name = "refresh_token", nullable = false, length = 1024)
     private String refreshToken;
 
     @Builder

--- a/src/main/java/com/example/dearfam/domain/users/entity/Users.java
+++ b/src/main/java/com/example/dearfam/domain/users/entity/Users.java
@@ -14,6 +14,7 @@ public class Users extends BaseTimeEntity {  // BaseTimeEntity에 생성일(crea
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id", nullable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -36,10 +37,13 @@ public class Users extends BaseTimeEntity {  // BaseTimeEntity에 생성일(crea
     @Column(name = "profile_image")
     private String profileImage;
 
+    @Column(name = "refresh_token", length = 1024)
     private String refreshToken;
 
     @Builder
+    public Users(Family family, String userNickName, String userRole, UserFamilyRole userFamilyRole, Boolean isFamilyRoomManager,
                  String profileImage, String refreshToken) {
+        this.family = family;
         this.userNickname = userNickName;
         this.userRole = userRole;
         this.userFamilyRole = userFamilyRole;

--- a/src/main/java/com/example/dearfam/domain/users/entity/Users.java
+++ b/src/main/java/com/example/dearfam/domain/users/entity/Users.java
@@ -1,6 +1,7 @@
 package com.example.dearfam.domain.users.entity;
 
 import com.example.dearfam.common.entity.BaseTimeEntity;
+import com.example.dearfam.domain.family.entity.Family;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -16,7 +17,9 @@ public class Users extends BaseTimeEntity {  // BaseTimeEntity에 생성일(crea
     @Column(name = "user_id")
     private Long id;
 
-    // TODO : family ID foreign key로 등록하기
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "family_id")
+    private Family family;
 
     @Column(name = "user_nickname", nullable = false, length = 50)
     private String userNickname;
@@ -24,8 +27,6 @@ public class Users extends BaseTimeEntity {  // BaseTimeEntity에 생성일(crea
     @Column(name = "user_role", nullable = false)
     private String userRole;
 
-    @Column(name = "user_family_role", nullable = false)
-    private String userFamilyRole;
 
     @Column(name = "is_family_room_manager")
     private Boolean isFamilyRoomManager;
@@ -37,7 +38,6 @@ public class Users extends BaseTimeEntity {  // BaseTimeEntity에 생성일(crea
     private String refreshToken;
 
     @Builder
-    public Users(String userNickName, String userRole, String userFamilyRole, Boolean isFamilyRoomManager,
                  String profileImage, String refreshToken) {
         this.userNickname = userNickName;
         this.userRole = userRole;

--- a/src/main/java/com/example/dearfam/domain/users/exception/UsersErrorCode.java
+++ b/src/main/java/com/example/dearfam/domain/users/exception/UsersErrorCode.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus;
 public enum UsersErrorCode implements ErrorCode {
     NICKNAME_ALREADY_EXISTS("이미 사용 중인 닉네임입니다.", HttpStatus.CONFLICT),
     USER_NOT_FOUND("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    USER_ALREADY_QUIT("이미 탈퇴한 사용자입니다.", HttpStatus.BAD_REQUEST),
     INVALID_USER_REQUEST("유효하지 않은 사용자 요청입니다.", HttpStatus.BAD_REQUEST),
     INVALID_ROLE("허용되지 않은 역할입니다.", HttpStatus.BAD_REQUEST),
     PROFILE_IMAGE_PROCESSING_ERROR("프로필 이미지 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/com/example/dearfam/domain/users/repository/UsersRepository.java
+++ b/src/main/java/com/example/dearfam/domain/users/repository/UsersRepository.java
@@ -6,10 +6,12 @@ import com.example.dearfam.domain.users.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface UsersRepository extends JpaRepository<Users, Long> {
     Optional<Users> findByUserNickname(String userNickname);
     boolean existsByFamilyAndUserFamilyRole(Family family, UserFamilyRole userFamilyRole);
+    List<Users> findAllByFamily(Family family);
 }

--- a/src/main/java/com/example/dearfam/domain/users/repository/UsersRepository.java
+++ b/src/main/java/com/example/dearfam/domain/users/repository/UsersRepository.java
@@ -1,5 +1,7 @@
 package com.example.dearfam.domain.users.repository;
 
+import com.example.dearfam.domain.family.entity.Family;
+import com.example.dearfam.domain.users.entity.UserFamilyRole;
 import com.example.dearfam.domain.users.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,4 +11,5 @@ import java.util.Optional;
 @Repository
 public interface UsersRepository extends JpaRepository<Users, Long> {
     Optional<Users> findByUserNickname(String userNickname);
+    boolean existsByFamilyAndUserFamilyRole(Family family, UserFamilyRole userFamilyRole);
 }

--- a/src/main/java/com/example/dearfam/domain/users/service/UsersPersistenceService.java
+++ b/src/main/java/com/example/dearfam/domain/users/service/UsersPersistenceService.java
@@ -13,8 +13,8 @@ public class UsersPersistenceService {
     private final UsersRepository usersRepository;
 
     @Transactional
-    public Users createUser(String userNickName, String userRole, String userFamilyRole, 
-                          Boolean isFamilyRoomManager, String profileImage) {
+    public Users createUser(String userNickName, String userRole,
+                            String profileImage) {
         // userRole 검증 로직
         if ("admin".equalsIgnoreCase(userRole)) {
             throw UsersErrorCode.INVALID_ROLE.defaultException();
@@ -23,16 +23,11 @@ public class UsersPersistenceService {
             userRole = "USER";
         }
         
-        // isFamilyRoomManager 검증 로직
-        if (isFamilyRoomManager == null) {
-            isFamilyRoomManager = false;
-        }
-        
         Users user = Users.builder()
                 .userNickName(userNickName)
                 .userRole(userRole)
-                .userFamilyRole(userFamilyRole)
-                .isFamilyRoomManager(isFamilyRoomManager)
+                .userFamilyRole(null)
+                .isFamilyRoomManager(false)
                 .profileImage(profileImage)
                 .refreshToken(null)
                 .build();

--- a/src/main/java/com/example/dearfam/domain/users/service/UsersPersistenceService.java
+++ b/src/main/java/com/example/dearfam/domain/users/service/UsersPersistenceService.java
@@ -24,6 +24,7 @@ public class UsersPersistenceService {
         }
         
         Users user = Users.builder()
+                .family(null)
                 .userNickName(userNickName)
                 .userRole(userRole)
                 .userFamilyRole(null)

--- a/src/main/java/com/example/dearfam/domain/users/service/UsersService.java
+++ b/src/main/java/com/example/dearfam/domain/users/service/UsersService.java
@@ -1,5 +1,8 @@
 package com.example.dearfam.domain.users.service;
 
+import com.example.dearfam.domain.family.controller.response.GetFamilyResponse;
+import com.example.dearfam.domain.family.dto.FamilyDto;
+import com.example.dearfam.domain.family.repository.FamilyRepository;
 import com.example.dearfam.domain.users.dto.UsersDto;
 import com.example.dearfam.domain.users.entity.Users;
 import com.example.dearfam.domain.users.exception.UsersErrorCode;
@@ -10,8 +13,8 @@ import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 
-@RequiredArgsConstructor
 @Service
+@RequiredArgsConstructor
 public class UsersService {
     private final UsersRepository usersRepository;
 
@@ -41,5 +44,15 @@ public class UsersService {
 
         user.setUserNickname(newNickname);
         usersRepository.save(user);
+    }
+
+    @Transactional
+    public GetFamilyResponse getUserFamily(Long userId) {
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(UsersErrorCode.USER_NOT_FOUND::defaultException);
+
+        FamilyDto familyDto = FamilyDto.from(user.getFamily());
+
+        return GetFamilyResponse.from(familyDto);
     }
 }

--- a/src/main/java/com/example/dearfam/domain/users/service/UsersService.java
+++ b/src/main/java/com/example/dearfam/domain/users/service/UsersService.java
@@ -1,9 +1,5 @@
 package com.example.dearfam.domain.users.service;
 
-import com.example.dearfam.domain.family.controller.response.GetFamilyResponse;
-import com.example.dearfam.domain.family.dto.FamilyDto;
-import com.example.dearfam.domain.family.entity.Family;
-import com.example.dearfam.domain.family.exception.FamilyErrorCode;
 import com.example.dearfam.domain.users.dto.UsersDto;
 import com.example.dearfam.domain.users.entity.Users;
 import com.example.dearfam.domain.users.exception.UsersErrorCode;
@@ -45,20 +41,5 @@ public class UsersService {
 
         user.setUserNickname(newNickname);
         usersRepository.save(user);
-    }
-
-    @Transactional
-    public GetFamilyResponse getUserFamily(Long userId) {
-        Users user = usersRepository.findById(userId)
-                .orElseThrow(UsersErrorCode.USER_NOT_FOUND::defaultException);
-
-        Family family = user.getFamily();
-        if (family == null) {
-            throw FamilyErrorCode.FAMILY_NOT_FOUND.defaultException();
-        }
-
-        FamilyDto familyDto = FamilyDto.from(user.getFamily());
-
-        return GetFamilyResponse.from(familyDto);
     }
 }

--- a/src/main/java/com/example/dearfam/domain/users/service/UsersService.java
+++ b/src/main/java/com/example/dearfam/domain/users/service/UsersService.java
@@ -2,7 +2,8 @@ package com.example.dearfam.domain.users.service;
 
 import com.example.dearfam.domain.family.controller.response.GetFamilyResponse;
 import com.example.dearfam.domain.family.dto.FamilyDto;
-import com.example.dearfam.domain.family.repository.FamilyRepository;
+import com.example.dearfam.domain.family.entity.Family;
+import com.example.dearfam.domain.family.exception.FamilyErrorCode;
 import com.example.dearfam.domain.users.dto.UsersDto;
 import com.example.dearfam.domain.users.entity.Users;
 import com.example.dearfam.domain.users.exception.UsersErrorCode;
@@ -50,6 +51,11 @@ public class UsersService {
     public GetFamilyResponse getUserFamily(Long userId) {
         Users user = usersRepository.findById(userId)
                 .orElseThrow(UsersErrorCode.USER_NOT_FOUND::defaultException);
+
+        Family family = user.getFamily();
+        if (family == null) {
+            throw FamilyErrorCode.FAMILY_NOT_FOUND.defaultException();
+        }
 
         FamilyDto familyDto = FamilyDto.from(user.getFamily());
 

--- a/src/test/java/com/example/dearfam/domain/family/invite/InviteLinkStoreTest.java
+++ b/src/test/java/com/example/dearfam/domain/family/invite/InviteLinkStoreTest.java
@@ -1,0 +1,63 @@
+package com.example.dearfam.domain.family.invite;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InviteLinkStoreTest {
+
+    private InviteLinkStore inviteLinkStore;
+
+    @BeforeEach
+    void setUp() {
+        inviteLinkStore = new InviteLinkStore();
+    }
+
+    @Test
+    void 초대코드_생성_저장_조회_성공() {
+        // given
+        String code = "ABC123";
+        Long familyId = 1L;
+        LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(5);
+
+        // when
+        inviteLinkStore.addCode(code, familyId, expiresAt);
+        Long result = inviteLinkStore.getFamilyId(code);
+
+        // then
+        assertThat(result).isEqualTo(familyId);
+    }
+
+    @Test
+    void 만료된_초대코드_조회시_null_반환_및_삭제() {
+        // given
+        String code = "EXPIRED";
+        Long familyId = 2L;
+        LocalDateTime expiresAt = LocalDateTime.now().minusMinutes(1); // 이미 만료
+
+        inviteLinkStore.addCode(code, familyId, expiresAt);
+
+        // when
+        Long result = inviteLinkStore.getFamilyId(code); // 유효성 체크 포함
+
+        // then
+        assertThat(result).isNull(); // 만료되었으니 null
+    }
+
+    @Test
+    void removeExpiredCode_실행시_만료된_코드_삭제됨() {
+        // given
+        inviteLinkStore.addCode("VALID", 1L, LocalDateTime.now().plusMinutes(5));
+        inviteLinkStore.addCode("EXPIRED", 2L, LocalDateTime.now().minusMinutes(1));
+
+        // when
+        inviteLinkStore.removeExpiredCode();
+
+        // then
+        assertThat(inviteLinkStore.getFamilyId("VALID")).isEqualTo(1L);
+        assertThat(inviteLinkStore.getFamilyId("EXPIRED")).isNull(); // removeExpiredCode로 제거됨
+    }
+}

--- a/src/test/java/com/example/dearfam/domain/family/service/InviteServiceTest.java
+++ b/src/test/java/com/example/dearfam/domain/family/service/InviteServiceTest.java
@@ -1,0 +1,87 @@
+package com.example.dearfam.domain.family.service;
+
+import com.example.dearfam.domain.family.dto.InviteLinkResponse;
+import com.example.dearfam.domain.family.entity.Family;
+import com.example.dearfam.domain.family.exception.InviteException;
+import com.example.dearfam.domain.family.invite.InviteLinkStore;
+import com.example.dearfam.domain.users.entity.Users;
+import com.example.dearfam.domain.users.repository.UsersRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InviteServiceTest {
+
+    @InjectMocks
+    private InviteService inviteService;
+
+    @Mock
+    private UsersRepository usersRepository;
+
+    @Mock
+    private InviteLinkStore inviteLinkStore;
+
+    @Test
+    void 초대링크_정상생성() {
+        // given
+        Long userId = 1L;
+        Long familyId = 10L;
+        String baseUrl = "http://localhost.com/invite";
+        Users mockUser = new Users();
+        Family mockFamily = new Family();
+        mockFamily.setId(familyId);
+        mockUser.setFamily(mockFamily);
+
+        when(usersRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+
+        ReflectionTestUtils.setField(inviteService, "inviteBaseUrl", baseUrl);
+
+        // when
+        InviteLinkResponse response = inviteService.generateInviteLink(userId);
+        System.out.println(response.getLink());
+
+        // then
+        assertThat(response.getCode()).hasSize(6);
+        assertThat(response.getLink()).startsWith(baseUrl);
+        verify(inviteLinkStore).addCode(anyString(), eq(familyId), any(LocalDateTime.class));
+    }
+
+    @Test
+    void 초대코드_유효성검증_성공() {
+        // given
+        String code = "ABC123";
+        Long familyId = 10L;
+        when(inviteLinkStore.getFamilyId(code)).thenReturn(familyId);
+
+        // when
+        Long result = inviteService.validateInviteCodeAndReturnFamilyId(code);
+
+        // then
+        assertThat(result).isEqualTo(familyId);
+    }
+
+    @Test
+    void 초대코드_유효성검증_실패() {
+        // given
+        String code = "EXPIRED";
+        when(inviteLinkStore.getFamilyId(code)).thenReturn(null);
+
+        // expect
+        assertThatThrownBy(() -> inviteService.validateInviteCodeAndReturnFamilyId(code))
+                .isInstanceOf(InviteException.class)
+                .hasMessageContaining("유효하지 않은 초대 코드");
+    }
+}

--- a/src/test/java/com/example/dearfam/domain/family/service/InviteServiceTest.java
+++ b/src/test/java/com/example/dearfam/domain/family/service/InviteServiceTest.java
@@ -1,6 +1,6 @@
 package com.example.dearfam.domain.family.service;
 
-import com.example.dearfam.domain.family.dto.InviteLinkResponse;
+import com.example.dearfam.domain.family.dto.InviteLinkDto;
 import com.example.dearfam.domain.family.entity.Family;
 import com.example.dearfam.domain.family.exception.InviteException;
 import com.example.dearfam.domain.family.invite.InviteLinkStore;
@@ -50,7 +50,7 @@ class InviteServiceTest {
         ReflectionTestUtils.setField(inviteService, "inviteBaseUrl", baseUrl);
 
         // when
-        InviteLinkResponse response = inviteService.generateInviteLink(userId);
+        InviteLinkDto response = inviteService.generateInviteLink(userId);
         System.out.println(response.getLink());
 
         // then


### PR DESCRIPTION
### 1. Family 로직 구현 완료
* 가족 생성
    - 가족을 생성하는 유저는 방장이 됨.
* 가족 내 역할 설정
    - 가족 생성 시 역할 상태는 null임.
    - 역할 선택 시, 아빠, 엄마는 한 명으로 제한.
    - 자녀는 아들, 딸 상관없이 최대 5명으로 제한함.
* 가족 조회
    - 로그인한 유저의 가족 조회 가능
    - 가족 ID를 통해서 가족 조회도 가능

### 2. 초대 링크 로직 및 가족 참여하기 로직 구현
- 초대 링크 현재는 로컬 주소로 구현. 추후 도메인 주소로 변경 예정
- 링크의 유효 시간은 하루임. 하루 뒤 링크의 유효성은 사라짐.
- 링크의 유효성 검사를 통해, 가족에 참여할 수 있음.
- 가족 참여 시, 참여하는 가족들은 모두 방장이 아닌 상태임.
