### PR TITLE
Validation 오류 처리 & 게시글, 게시글 참여 가족, 댓글, 좋아요 로직 구현

### DIFF
--- a/src/main/java/com/example/dearfam/common/dto/exception/ApiResponseError.java
+++ b/src/main/java/com/example/dearfam/common/dto/exception/ApiResponseError.java
@@ -42,6 +42,19 @@ public record ApiResponseError(
                 .build();
     }
 
+    public static ApiResponseError of(CustomException exception, List<ApiSimpleError> validationErrors) {
+        ErrorCode errorCode = exception.getErrorCode();
+        String errorName = exception.getClass().getSimpleName();
+
+        return ApiResponseError.builder()
+                .code(errorCode.name())
+                .status(errorCode.defaultHttpStatus().value())
+                .name(errorName)
+                .message(exception.getMessage())
+                .cause(validationErrors)
+                .build();
+    }
+
     public ApiResponseError {
         if (code == null) code = "API ERROR";
         if (status == null) status = 500;

--- a/src/main/java/com/example/dearfam/common/dto/exception/ApiSimpleError.java
+++ b/src/main/java/com/example/dearfam/common/dto/exception/ApiSimpleError.java
@@ -2,8 +2,10 @@ package com.example.dearfam.common.dto.exception;
 
 import lombok.Builder;
 import lombok.NonNull;
+import org.springframework.validation.FieldError;
 
 import java.util.List;
+import java.util.Objects;
 
 @Builder
 public record ApiSimpleError(@NonNull String field, @NonNull String message) {
@@ -38,4 +40,12 @@ public record ApiSimpleError(@NonNull String field, @NonNull String message) {
 
         return subErrors;
     }
+
+    // Validation Error 기반 (FieldError 목록 처리)
+    public static List<ApiSimpleError> ofFieldErrors(List<FieldError> fieldErrors) {
+        return fieldErrors.stream()
+                .map(error -> new ApiSimpleError(error.getField(), Objects.requireNonNull(error.getDefaultMessage())))
+                .toList();
+    }
+
 }

--- a/src/main/java/com/example/dearfam/common/exception/ValidationException.java
+++ b/src/main/java/com/example/dearfam/common/exception/ValidationException.java
@@ -1,0 +1,25 @@
+package com.example.dearfam.common.exception;
+
+import com.example.dearfam.common.exception.errorcode.ErrorCode;
+
+public class ValidationException extends CustomException {
+    public ValidationException() {
+        super();
+    }
+
+    public ValidationException(String message) {
+        super(message);
+    }
+
+    public ValidationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ValidationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public ValidationException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
+}

--- a/src/main/java/com/example/dearfam/common/exception/errorcode/ValidationErrorCode.java
+++ b/src/main/java/com/example/dearfam/common/exception/errorcode/ValidationErrorCode.java
@@ -1,0 +1,33 @@
+package com.example.dearfam.common.exception.errorcode;
+
+import com.example.dearfam.common.exception.ValidationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum ValidationErrorCode implements ErrorCode {
+    INVALID_REQUEST("유효하지 않은 Request 입니다.", HttpStatus.BAD_REQUEST);
+
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    @Override
+    public HttpStatus defaultHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String defaultMessage() {
+        return message;
+    }
+
+    @Override
+    public ValidationException defaultException() {
+        return new ValidationException(this);
+    }
+
+    @Override
+    public ValidationException defaultException(Throwable cause) {
+        return new ValidationException(this, cause);
+    }
+}

--- a/src/main/java/com/example/dearfam/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/dearfam/common/exception/handler/GlobalExceptionHandler.java
@@ -1,12 +1,17 @@
 package com.example.dearfam.common.exception.handler;
 
 import com.example.dearfam.common.dto.exception.ApiResponseError;
+import com.example.dearfam.common.dto.exception.ApiSimpleError;
 import com.example.dearfam.common.exception.CustomException;
 import com.example.dearfam.common.exception.NoContentException;
+import com.example.dearfam.common.exception.errorcode.ValidationErrorCode;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
 
 @RestControllerAdvice
 public final class GlobalExceptionHandler {
@@ -24,6 +29,19 @@ public final class GlobalExceptionHandler {
     @ExceptionHandler(NoContentException.class)
     public ResponseEntity<?> handleNoContentException(NoContentException exception) {
         return ResponseEntity.noContent().build();
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponseError> handleValidationException(MethodArgumentNotValidException exception) {
+        List<ApiSimpleError> fieldErrors = ApiSimpleError.ofFieldErrors(exception.getBindingResult().getFieldErrors());
+
+        ApiResponseError responseError = ApiResponseError.of(
+                ValidationErrorCode.INVALID_REQUEST.defaultException(),
+                fieldErrors
+        );
+        HttpStatus httpStatus = ValidationErrorCode.INVALID_REQUEST.defaultHttpStatus();
+
+        return new ResponseEntity<>(responseError, httpStatus);
     }
 
 }

--- a/src/main/java/com/example/dearfam/domain/auth/controller/request/OAuth2LoginRequest.java
+++ b/src/main/java/com/example/dearfam/domain/auth/controller/request/OAuth2LoginRequest.java
@@ -3,8 +3,10 @@ package com.example.dearfam.domain.auth.controller.request;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class OAuth2LoginRequest {
 

--- a/src/main/java/com/example/dearfam/domain/auth/service/OAuth2Service.java
+++ b/src/main/java/com/example/dearfam/domain/auth/service/OAuth2Service.java
@@ -7,9 +7,9 @@ import com.example.dearfam.domain.auth.exception.AuthErrorCode;
 import com.example.dearfam.domain.users.entity.Users;
 import com.example.dearfam.domain.users.repository.UsersRepository;
 import com.example.dearfam.domain.users.service.UsersPersistenceService;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 

--- a/src/main/java/com/example/dearfam/domain/family/controller/request/FamilyNameRequest.java
+++ b/src/main/java/com/example/dearfam/domain/family/controller/request/FamilyNameRequest.java
@@ -3,10 +3,12 @@ package com.example.dearfam.domain.family.controller.request;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class FamilyNameRequest {
     @NotEmpty
-    private final String familyName;
+    private String familyName;
 }

--- a/src/main/java/com/example/dearfam/domain/family/controller/request/UserFamilyRoleRequest.java
+++ b/src/main/java/com/example/dearfam/domain/family/controller/request/UserFamilyRoleRequest.java
@@ -4,8 +4,10 @@ import com.example.dearfam.domain.users.entity.UserFamilyRole;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class UserFamilyRoleRequest {
 

--- a/src/main/java/com/example/dearfam/domain/family/service/FamilyService.java
+++ b/src/main/java/com/example/dearfam/domain/family/service/FamilyService.java
@@ -139,18 +139,13 @@ public class FamilyService {
         List<Users> members = usersRepository.findAllByFamily(family);
 
         return members.stream()
-                .sorted(Comparator.comparing((Users u) -> {
-                    UserFamilyRole userFamilyRole = u.getUserFamilyRole();
-                    if (userFamilyRole == null) return 3; // 제일 마지막
-                    if (userFamilyRole == UserFamilyRole.FATHER) return 0;
-                    if (userFamilyRole == UserFamilyRole.MOTHER) return 1;
-                    return 2;
-                }).thenComparing(BaseTimeEntity::getCreatedAt))
-                .map(member -> FamilyMemberDto.from(
-                        member.getId(),
-                        member.getUserNickname(),
-                        member.getUserFamilyRole()
-                ))
+                .sorted(Comparator
+                        .comparing((Users u) -> {
+                            UserFamilyRole userFamilyRole = u.getUserFamilyRole();
+                            return userFamilyRole != null ? userFamilyRole.getSortOrder() : Integer.MAX_VALUE;
+                        })
+                        .thenComparing(BaseTimeEntity::getCreatedAt))
+                .map(FamilyMemberDto::from)
                 .toList();
     }
 

--- a/src/main/java/com/example/dearfam/domain/family/service/FamilyService.java
+++ b/src/main/java/com/example/dearfam/domain/family/service/FamilyService.java
@@ -11,9 +11,9 @@ import com.example.dearfam.domain.users.entity.UserFamilyRole;
 import com.example.dearfam.domain.users.entity.Users;
 import com.example.dearfam.domain.users.exception.UsersErrorCode;
 import com.example.dearfam.domain.users.repository.UsersRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.List;
@@ -104,7 +104,7 @@ public class FamilyService {
     }
 
 
-    @Transactional
+    @Transactional(readOnly = true)
     public GetFamilyResponse getUserFamily(Long userId) {
         Users user = usersRepository.findById(userId)
                 .orElseThrow(UsersErrorCode.USER_NOT_FOUND::defaultException);
@@ -121,7 +121,7 @@ public class FamilyService {
         return GetFamilyResponse.from(familyDto, familyMembers);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public GetFamilyResponse getFamilyByFamilyId(Long familyId) {
         Family family = familyRepository.findById(familyId)
                 .orElseThrow(FamilyErrorCode.FAMILY_NOT_FOUND::defaultException);

--- a/src/main/java/com/example/dearfam/domain/memoryposts/comment/controller/MemoryPostCommentController.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/comment/controller/MemoryPostCommentController.java
@@ -1,0 +1,87 @@
+package com.example.dearfam.domain.memoryposts.comment.controller;
+
+import com.example.dearfam.common.dto.response.Response;
+import com.example.dearfam.common.jwt.auth.JwtService;
+import com.example.dearfam.domain.memoryposts.comment.controller.request.CreateCommentRequest;
+import com.example.dearfam.domain.memoryposts.comment.controller.response.GetAllCommentResponse;
+import com.example.dearfam.domain.memoryposts.comment.controller.response.GetCreatedCommentResponse;
+import com.example.dearfam.domain.memoryposts.comment.dto.MemoryPostCommentDto;
+import com.example.dearfam.domain.memoryposts.comment.service.MemoryPostCommentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/memory-post/{postId}/comment")
+@Tag(name = "Memory Post Comment Controller", description = "추억 게시글 댓글 관련 기능을 처리하는 API")
+public class MemoryPostCommentController {
+
+    private final JwtService jwtService;
+    private final MemoryPostCommentService memoryPostCommentService;
+
+    @Operation(
+            summary = "댓글 생성",
+            description = "게시글의 댓글을 생성하고, DB에 저장하는 API입니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "404", description = "작성자, 게시글 정보를 찾을 수 없음"),
+                    @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
+            }
+    )
+    @PostMapping
+    public Response<GetCreatedCommentResponse> createMemoryPostComment(@Valid @RequestBody CreateCommentRequest request, @PathVariable Long postId) {
+        Long writerId = jwtService.getTokenDto().getUserId();
+        String content = request.getContent();
+
+        MemoryPostCommentDto memoryPostCommentDto = memoryPostCommentService.createMemoryPostComment(writerId, postId, content);
+
+        GetCreatedCommentResponse response = GetCreatedCommentResponse.from(memoryPostCommentDto);
+
+        return Response.data(response);
+    }
+
+    @Operation(
+            summary = "댓글 삭제",
+            description = "작성자가 자신이 작성한 댓글을 삭제하는 API입니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "403", description = "삭제 권한이 없는 사용자"),
+                    @ApiResponse(responseCode = "404", description = "게시글, 댓글 정보를 찾을 수 없음"),
+                    @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
+            }
+    )
+    @DeleteMapping("/{commentId}")
+    public Response<String> deleteMemoryPostComment(@PathVariable Long postId, @PathVariable Long commentId) {
+        Long writerId = jwtService.getTokenDto().getUserId();
+
+        memoryPostCommentService.deleteMemoryPostComment(writerId, postId, commentId);
+
+        return Response.data("댓글이 삭제되었습니다.");
+    }
+
+    @Operation(
+            summary = "게시글 댓글 조회",
+            description = "한 게시글의 모든 댓글을 생성된 순서대로 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "404", description = "게시글 정보를 찾을 수 없음"),
+                    @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
+            }
+    )
+    @GetMapping
+    public Response<List<GetAllCommentResponse>> getAllCommentsFromMemoryPost(@PathVariable Long postId) {
+
+        List<MemoryPostCommentDto> memoryPostCommentDtoList = memoryPostCommentService.getCommentsFromMemoryPost(postId);
+
+        List<GetAllCommentResponse> response = GetAllCommentResponse.from(memoryPostCommentDtoList);
+
+        return Response.data(response);
+    }
+
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/comment/controller/request/CreateCommentRequest.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/comment/controller/request/CreateCommentRequest.java
@@ -1,0 +1,14 @@
+package com.example.dearfam.domain.memoryposts.comment.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateCommentRequest {
+    @NotBlank
+    private String content;
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/comment/controller/response/GetAllCommentResponse.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/comment/controller/response/GetAllCommentResponse.java
@@ -1,7 +1,6 @@
 package com.example.dearfam.domain.memoryposts.comment.controller.response;
 
 import com.example.dearfam.domain.memoryposts.comment.dto.MemoryPostCommentDto;
-import com.example.dearfam.domain.memoryposts.memorypost.controller.response.GetMemoryPostResponse;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/example/dearfam/domain/memoryposts/comment/controller/response/GetAllCommentResponse.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/comment/controller/response/GetAllCommentResponse.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -16,14 +15,15 @@ import static lombok.AccessLevel.PRIVATE;
 @Builder(access = PRIVATE)
 public class GetAllCommentResponse {
     private Long commentWriterId;
+    private String commentWriterName;
     private String content;
-    private LocalDateTime createdAt;
+    // TODO : 추후 이미지 처리 해야함.
 
     public static GetAllCommentResponse from(MemoryPostCommentDto memoryPostCommentDto) {
         return GetAllCommentResponse.builder()
                 .commentWriterId(memoryPostCommentDto.getCommentWriter().getId())
+                .commentWriterName(memoryPostCommentDto.getCommentWriter().getUserNickname())
                 .content(memoryPostCommentDto.getCommentContent())
-                .createdAt(memoryPostCommentDto.getCreatedAt())
                 .build();
     }
 

--- a/src/main/java/com/example/dearfam/domain/memoryposts/comment/controller/response/GetAllCommentResponse.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/comment/controller/response/GetAllCommentResponse.java
@@ -16,13 +16,13 @@ import static lombok.AccessLevel.PRIVATE;
 @AllArgsConstructor
 @Builder(access = PRIVATE)
 public class GetAllCommentResponse {
-    private Long writerId;
+    private Long commentWriterId;
     private String content;
     private LocalDateTime createdAt;
 
     public static GetAllCommentResponse from(MemoryPostCommentDto memoryPostCommentDto) {
         return GetAllCommentResponse.builder()
-                .writerId(memoryPostCommentDto.getMemoryPost().getWriter().getId())
+                .commentWriterId(memoryPostCommentDto.getCommentWriter().getId())
                 .content(memoryPostCommentDto.getCommentContent())
                 .createdAt(memoryPostCommentDto.getCreatedAt())
                 .build();

--- a/src/main/java/com/example/dearfam/domain/memoryposts/comment/controller/response/GetAllCommentResponse.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/comment/controller/response/GetAllCommentResponse.java
@@ -1,0 +1,36 @@
+package com.example.dearfam.domain.memoryposts.comment.controller.response;
+
+import com.example.dearfam.domain.memoryposts.comment.dto.MemoryPostCommentDto;
+import com.example.dearfam.domain.memoryposts.memorypost.controller.response.GetMemoryPostResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@AllArgsConstructor
+@Builder(access = PRIVATE)
+public class GetAllCommentResponse {
+    private Long writerId;
+    private String content;
+    private LocalDateTime createdAt;
+
+    public static GetAllCommentResponse from(MemoryPostCommentDto memoryPostCommentDto) {
+        return GetAllCommentResponse.builder()
+                .writerId(memoryPostCommentDto.getMemoryPost().getWriter().getId())
+                .content(memoryPostCommentDto.getCommentContent())
+                .createdAt(memoryPostCommentDto.getCreatedAt())
+                .build();
+    }
+
+    public static List<GetAllCommentResponse> from(List<MemoryPostCommentDto> memoryPostCommentDtoList) {
+        return memoryPostCommentDtoList.stream()
+                .map(GetAllCommentResponse::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/comment/controller/response/GetCreatedCommentResponse.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/comment/controller/response/GetCreatedCommentResponse.java
@@ -12,13 +12,13 @@ import static lombok.AccessLevel.PRIVATE;
 @Builder(access = PRIVATE)
 public class GetCreatedCommentResponse {
     private Long postId;
-    private Long writerId;
+    private Long commentWriterId;
     private String content;
 
     public static GetCreatedCommentResponse from(MemoryPostCommentDto memoryPostCommentDto) {
         return GetCreatedCommentResponse.builder()
                 .postId(memoryPostCommentDto.getMemoryPost().getId())
-                .writerId(memoryPostCommentDto.getMemoryPost().getWriter().getId())
+                .commentWriterId(memoryPostCommentDto.getCommentWriter().getId())
                 .content(memoryPostCommentDto.getCommentContent())
                 .build();
     }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/comment/controller/response/GetCreatedCommentResponse.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/comment/controller/response/GetCreatedCommentResponse.java
@@ -1,0 +1,25 @@
+package com.example.dearfam.domain.memoryposts.comment.controller.response;
+
+import com.example.dearfam.domain.memoryposts.comment.dto.MemoryPostCommentDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@AllArgsConstructor
+@Builder(access = PRIVATE)
+public class GetCreatedCommentResponse {
+    private Long postId;
+    private Long writerId;
+    private String content;
+
+    public static GetCreatedCommentResponse from(MemoryPostCommentDto memoryPostCommentDto) {
+        return GetCreatedCommentResponse.builder()
+                .postId(memoryPostCommentDto.getMemoryPost().getId())
+                .writerId(memoryPostCommentDto.getMemoryPost().getWriter().getId())
+                .content(memoryPostCommentDto.getCommentContent())
+                .build();
+    }
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/comment/controller/response/GetCreatedCommentResponse.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/comment/controller/response/GetCreatedCommentResponse.java
@@ -13,12 +13,15 @@ import static lombok.AccessLevel.PRIVATE;
 public class GetCreatedCommentResponse {
     private Long postId;
     private Long commentWriterId;
+    private String commentWriterName;
     private String content;
+    // TODO : 이미지 처리 해야함
 
     public static GetCreatedCommentResponse from(MemoryPostCommentDto memoryPostCommentDto) {
         return GetCreatedCommentResponse.builder()
                 .postId(memoryPostCommentDto.getMemoryPost().getId())
                 .commentWriterId(memoryPostCommentDto.getCommentWriter().getId())
+                .commentWriterName(memoryPostCommentDto.getCommentWriter().getUserNickname())
                 .content(memoryPostCommentDto.getCommentContent())
                 .build();
     }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/comment/dto/MemoryPostCommentDto.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/comment/dto/MemoryPostCommentDto.java
@@ -1,0 +1,33 @@
+package com.example.dearfam.domain.memoryposts.comment.dto;
+
+import com.example.dearfam.domain.memoryposts.comment.entity.MemoryPostComment;
+import com.example.dearfam.domain.memoryposts.memorypost.entity.MemoryPost;
+import com.example.dearfam.domain.users.entity.Users;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class MemoryPostCommentDto {
+    private final Long commentId;
+    private final MemoryPost memoryPost;
+    private final Users commentWriter;
+    private final String commentContent;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public static MemoryPostCommentDto from(MemoryPostComment memoryPostComment) {
+        return MemoryPostCommentDto.builder()
+                .commentId(memoryPostComment.getId())
+                .memoryPost(memoryPostComment.getMemoryPost())
+                .commentWriter(memoryPostComment.getCommentWriter())
+                .commentContent(memoryPostComment.getCommentContent())
+                .createdAt(memoryPostComment.getCreatedAt())
+                .updatedAt(memoryPostComment.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/comment/entity/MemoryPostComment.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/comment/entity/MemoryPostComment.java
@@ -1,0 +1,43 @@
+package com.example.dearfam.domain.memoryposts.comment.entity;
+
+import com.example.dearfam.common.entity.BaseTimeEntity;
+import com.example.dearfam.domain.memoryposts.memorypost.entity.MemoryPost;
+import com.example.dearfam.domain.users.entity.Users;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "memory_post_comment")
+public class MemoryPostComment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "memory_post_comment_id", nullable = false)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "memory_post_id", nullable = false)
+    private MemoryPost memoryPost;
+
+    @ManyToOne
+    @JoinColumn(name = "comment_writer_id", nullable = false)
+    private Users commentWriter;
+
+    @Column(name = "comment_content", nullable = false)
+    private String commentContent;
+
+    @Builder
+    public MemoryPostComment(MemoryPost memoryPost, Users commentWriter, String commentContent) {
+        this.memoryPost = memoryPost;
+        this.commentWriter = commentWriter;
+        this.commentContent = commentContent;
+    }
+
+
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/comment/exception/MemoryPostCommentErrorCode.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/comment/exception/MemoryPostCommentErrorCode.java
@@ -1,0 +1,35 @@
+package com.example.dearfam.domain.memoryposts.comment.exception;
+
+import com.example.dearfam.common.exception.errorcode.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum MemoryPostCommentErrorCode implements ErrorCode {
+    COMMENT_NOT_FOUND("댓글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    UNAUTHORIZED_WRITER("삭제 권한이 없는 사용자입니다.", HttpStatus.FORBIDDEN),
+    DEFAULT("게시글 댓글 처리 중 문제가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final String message;
+    private final HttpStatus status;
+
+    @Override
+    public HttpStatus defaultHttpStatus() {
+        return status;
+    }
+
+    @Override
+    public String defaultMessage() {
+        return message;
+    }
+
+    @Override
+    public MemoryPostCommentException defaultException() {
+        return new MemoryPostCommentException(this);
+    }
+
+    @Override
+    public MemoryPostCommentException defaultException(Throwable cause) {
+        return new MemoryPostCommentException(this, cause);
+    }
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/comment/exception/MemoryPostCommentException.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/comment/exception/MemoryPostCommentException.java
@@ -1,0 +1,26 @@
+package com.example.dearfam.domain.memoryposts.comment.exception;
+
+import com.example.dearfam.common.exception.CustomException;
+import com.example.dearfam.common.exception.errorcode.ErrorCode;
+
+public class MemoryPostCommentException extends CustomException {
+    public MemoryPostCommentException() {
+      super();
+    }
+
+    public MemoryPostCommentException(String message) {
+      super(message);
+    }
+
+    public MemoryPostCommentException(String message, Throwable cause) {
+      super(message, cause);
+    }
+
+    public MemoryPostCommentException(ErrorCode errorCode) {
+      super(errorCode);
+    }
+
+    public MemoryPostCommentException(ErrorCode errorCode, Throwable cause) {
+      super(errorCode, cause);
+    }
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/comment/repository/MemoryPostCommentRepository.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/comment/repository/MemoryPostCommentRepository.java
@@ -1,0 +1,13 @@
+package com.example.dearfam.domain.memoryposts.comment.repository;
+
+import com.example.dearfam.domain.memoryposts.comment.entity.MemoryPostComment;
+import com.example.dearfam.domain.memoryposts.memorypost.entity.MemoryPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MemoryPostCommentRepository extends JpaRepository<MemoryPostComment, Long> {
+    List<MemoryPostComment> findAllByMemoryPostOrderByCreatedAtAsc(MemoryPost memoryPost);
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/comment/service/MemoryPostCommentService.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/comment/service/MemoryPostCommentService.java
@@ -1,0 +1,84 @@
+package com.example.dearfam.domain.memoryposts.comment.service;
+
+import com.example.dearfam.domain.memoryposts.comment.dto.MemoryPostCommentDto;
+import com.example.dearfam.domain.memoryposts.comment.entity.MemoryPostComment;
+import com.example.dearfam.domain.memoryposts.comment.exception.MemoryPostCommentErrorCode;
+import com.example.dearfam.domain.memoryposts.comment.repository.MemoryPostCommentRepository;
+import com.example.dearfam.domain.memoryposts.memorypost.entity.MemoryPost;
+import com.example.dearfam.domain.memoryposts.memorypost.exception.MemoryPostErrorCode;
+import com.example.dearfam.domain.memoryposts.memorypost.repository.MemoryPostRepository;
+import com.example.dearfam.domain.users.entity.Users;
+import com.example.dearfam.domain.users.exception.UsersErrorCode;
+import com.example.dearfam.domain.users.repository.UsersRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MemoryPostCommentService {
+
+    private final UsersRepository usersRepository;
+    private final MemoryPostRepository memoryPostRepository;
+    private final MemoryPostCommentRepository memoryPostCommentRepository;
+
+    @Transactional
+    public MemoryPostCommentDto createMemoryPostComment(Long writerId, Long postId, String commentContent) {
+
+        Users writer = usersRepository.findById(writerId)
+                .orElseThrow(UsersErrorCode.USER_NOT_FOUND::defaultException);
+
+        MemoryPost memoryPost = memoryPostRepository.findById(postId)
+                .orElseThrow(MemoryPostErrorCode.MEMORY_POST_NOT_FOUND::defaultException);
+
+        MemoryPostComment memoryPostComment = MemoryPostComment.builder()
+                .memoryPost(memoryPost)
+                .commentWriter(writer)
+                .commentContent(commentContent)
+                .build();
+
+        memoryPostCommentRepository.save(memoryPostComment);
+
+        memoryPost.setMemoryPostCommentCount(memoryPost.getMemoryPostCommentCount() + 1);
+        memoryPostRepository.save(memoryPost);
+
+
+        return MemoryPostCommentDto.from(memoryPostComment);
+    }
+
+    @Transactional
+    public void deleteMemoryPostComment(Long writerId, Long postId, Long commentId) {
+
+        MemoryPost memoryPost = memoryPostRepository.findById(postId)
+                .orElseThrow(MemoryPostErrorCode.MEMORY_POST_NOT_FOUND::defaultException);
+
+        MemoryPostComment comment = memoryPostCommentRepository.findById(commentId)
+                .orElseThrow(MemoryPostCommentErrorCode.COMMENT_NOT_FOUND::defaultException);
+
+        // 삭제 권한이 있는지 확인
+        if (!comment.getCommentWriter().getId().equals(writerId)) {
+            throw MemoryPostCommentErrorCode.UNAUTHORIZED_WRITER.defaultException();
+        }
+
+        memoryPost.setMemoryPostCommentCount(memoryPost.getMemoryPostCommentCount() - 1);
+        memoryPostCommentRepository.delete(comment);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MemoryPostCommentDto> getCommentsFromMemoryPost(Long postId) {
+
+        MemoryPost memoryPost = memoryPostRepository.findById(postId)
+                .orElseThrow(MemoryPostErrorCode.MEMORY_POST_NOT_FOUND::defaultException);
+
+        List<MemoryPostComment> comments = memoryPostCommentRepository
+                .findAllByMemoryPostOrderByCreatedAtAsc(memoryPost);
+
+        return comments.stream()
+                .map(MemoryPostCommentDto::from)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/like/controller/MemoryPostLikeController.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/like/controller/MemoryPostLikeController.java
@@ -4,6 +4,7 @@ import com.example.dearfam.common.dto.response.Response;
 import com.example.dearfam.common.jwt.auth.JwtService;
 import com.example.dearfam.domain.memoryposts.like.service.MemoryPostLikeService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -24,7 +25,8 @@ public class MemoryPostLikeController {
             summary = "게시글 좋아요",
             description = "사용자가 요청한 게시글 좋아요 API. 한 번 더 누르면 좋아요 취소임",
             responses = {
-
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
             }
     )
     @PutMapping("/{postId}/like")

--- a/src/main/java/com/example/dearfam/domain/memoryposts/like/controller/MemoryPostLikeController.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/like/controller/MemoryPostLikeController.java
@@ -1,0 +1,38 @@
+package com.example.dearfam.domain.memoryposts.like.controller;
+
+import com.example.dearfam.common.dto.response.Response;
+import com.example.dearfam.common.jwt.auth.JwtService;
+import com.example.dearfam.domain.memoryposts.like.service.MemoryPostLikeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/memory-post")
+@Tag(name = "Memory Post Like Controller", description = "추억 게시글 좋아요 처리 API")
+public class MemoryPostLikeController {
+
+    private final JwtService jwtService;
+    private final MemoryPostLikeService memoryPostLikeService;
+
+    @Operation(
+            summary = "게시글 좋아요",
+            description = "사용자가 요청한 게시글 좋아요 API. 한 번 더 누르면 좋아요 취소임",
+            responses = {
+
+            }
+    )
+    @PutMapping("/{postId}/like")
+    public Response<String> memoryPostLikeOrUnlike(@PathVariable Long postId) {
+        Long likedUserId = jwtService.getTokenDto().getUserId();
+
+        String response = memoryPostLikeService.likeOrUnlikeMemoryPost(likedUserId, postId);
+
+        return Response.data(response);
+    }
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/like/dto/MemoryPostLikeDto.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/like/dto/MemoryPostLikeDto.java
@@ -1,0 +1,32 @@
+package com.example.dearfam.domain.memoryposts.like.dto;
+
+import com.example.dearfam.domain.memoryposts.like.entity.MemoryPostLike;
+import com.example.dearfam.domain.memoryposts.memorypost.entity.MemoryPost;
+import com.example.dearfam.domain.users.entity.Users;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class MemoryPostLikeDto {
+    private Long MemoryPostLikeId;
+    private MemoryPost memoryPost;
+    private Users likedUser;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static MemoryPostLikeDto from(MemoryPostLike memoryPostLike) {
+        return MemoryPostLikeDto.builder()
+                .MemoryPostLikeId(memoryPostLike.getMemoryPostLikeId())
+                .memoryPost(memoryPostLike.getMemoryPost())
+                .likedUser(memoryPostLike.getLikedUser())
+                .createdAt(memoryPostLike.getCreatedAt())
+                .updatedAt(memoryPostLike.getUpdatedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/like/entity/MemoryPostLike.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/like/entity/MemoryPostLike.java
@@ -32,10 +32,14 @@ public class MemoryPostLike extends BaseTimeEntity {
     @JoinColumn(name = "liked_user_id", nullable = false)
     private Users likedUser;
 
+    @Column(nullable = false)
+    private boolean liked;
+
     @Builder
-    public MemoryPostLike(MemoryPost memoryPost, Users likedUser) {
+    public MemoryPostLike(MemoryPost memoryPost, Users likedUser, boolean liked) {
         this.memoryPost = memoryPost;
         this.likedUser = likedUser;
+        this.liked = liked;
     }
 
 }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/like/entity/MemoryPostLike.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/like/entity/MemoryPostLike.java
@@ -1,0 +1,41 @@
+package com.example.dearfam.domain.memoryposts.like.entity;
+
+import com.example.dearfam.common.entity.BaseTimeEntity;
+import com.example.dearfam.domain.memoryposts.memorypost.entity.MemoryPost;
+import com.example.dearfam.domain.users.entity.Users;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(
+        name = "memory_post_like",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"liked_user_id", "memory_post_id"})
+)
+public class MemoryPostLike extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "memory_post_like_id", nullable = false)
+    private Long memoryPostLikeId;
+
+    @ManyToOne
+    @JoinColumn(name = "memory_post_id", nullable = false)
+    private MemoryPost memoryPost;
+
+    @ManyToOne
+    @JoinColumn(name = "liked_user_id", nullable = false)
+    private Users likedUser;
+
+    @Builder
+    public MemoryPostLike(MemoryPost memoryPost, Users likedUser) {
+        this.memoryPost = memoryPost;
+        this.likedUser = likedUser;
+    }
+
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/like/repository/MemoryPostLikeRepository.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/like/repository/MemoryPostLikeRepository.java
@@ -1,0 +1,12 @@
+package com.example.dearfam.domain.memoryposts.like.repository;
+
+import com.example.dearfam.domain.memoryposts.like.entity.MemoryPostLike;
+import com.example.dearfam.domain.memoryposts.memorypost.entity.MemoryPost;
+import com.example.dearfam.domain.users.entity.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemoryPostLikeRepository extends JpaRepository<MemoryPostLike, Long> {
+    MemoryPostLike findMemoryPostLikeByLikedUserAndMemoryPost(Users likedUser, MemoryPost memoryPost);
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/like/repository/MemoryPostLikeRepository.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/like/repository/MemoryPostLikeRepository.java
@@ -8,6 +8,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemoryPostLikeRepository extends JpaRepository<MemoryPostLike, Long> {
-    MemoryPostLike findMemoryPostLikeByLikedUserAndMemoryPost(Users likedUser, MemoryPost memoryPost);
+    MemoryPostLike findByLikedUserAndMemoryPost(Users likedUser, MemoryPost memoryPost);
     boolean existsByLikedUserAndMemoryPost(Users likedUser, MemoryPost memoryPost);
 }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/like/repository/MemoryPostLikeRepository.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/like/repository/MemoryPostLikeRepository.java
@@ -9,4 +9,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MemoryPostLikeRepository extends JpaRepository<MemoryPostLike, Long> {
     MemoryPostLike findMemoryPostLikeByLikedUserAndMemoryPost(Users likedUser, MemoryPost memoryPost);
+    boolean existsByLikedUserAndMemoryPost(Users likedUser, MemoryPost memoryPost);
 }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/like/service/MemoryPostLikeService.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/like/service/MemoryPostLikeService.java
@@ -29,24 +29,26 @@ public class MemoryPostLikeService {
         MemoryPost memoryPost = memoryPostRepository.findById(postId)
                 .orElseThrow(MemoryPostErrorCode.MEMORY_POST_NOT_FOUND::defaultException);
 
-        MemoryPostLike likedInfo = memoryPostLikeRepository.findMemoryPostLikeByLikedUserAndMemoryPost(likedUser, memoryPost);
+        MemoryPostLike like = memoryPostLikeRepository.findByLikedUserAndMemoryPost(likedUser, memoryPost);
 
-        String response;
-
-        if (likedInfo == null) {
-            likedInfo = MemoryPostLike.builder()
+        if (like == null) {
+            like = MemoryPostLike.builder()
                     .likedUser(likedUser)
                     .memoryPost(memoryPost)
+                    .liked(true)
                     .build();
-
-            memoryPostLikeRepository.save(likedInfo);
-            response = "게시글에 좋아요를 눌렀습니다.";
-        } else {
-            memoryPostLikeRepository.delete(likedInfo);
-            response = "게시글의 좋아요를 취소했습니다.";
+            memoryPostLikeRepository.save(like);
+            return "좋아요를 눌렀습니다.";
         }
 
-        return response;
+        if (like.isLiked()) {
+            like.setLiked(false);
+            return "좋아요를 취소했습니다.";
+        } else {
+            like.setLiked(true);
+            return "좋아요를 다시 눌렀습니다.";
+        }
+
     }
 
 }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/like/service/MemoryPostLikeService.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/like/service/MemoryPostLikeService.java
@@ -1,0 +1,52 @@
+package com.example.dearfam.domain.memoryposts.like.service;
+
+import com.example.dearfam.domain.memoryposts.like.entity.MemoryPostLike;
+import com.example.dearfam.domain.memoryposts.like.repository.MemoryPostLikeRepository;
+import com.example.dearfam.domain.memoryposts.memorypost.entity.MemoryPost;
+import com.example.dearfam.domain.memoryposts.memorypost.exception.MemoryPostErrorCode;
+import com.example.dearfam.domain.memoryposts.memorypost.repository.MemoryPostRepository;
+import com.example.dearfam.domain.users.entity.Users;
+import com.example.dearfam.domain.users.exception.UsersErrorCode;
+import com.example.dearfam.domain.users.repository.UsersRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemoryPostLikeService {
+
+    private final UsersRepository usersRepository;
+    private final MemoryPostRepository memoryPostRepository;
+    private final MemoryPostLikeRepository memoryPostLikeRepository;
+
+    @Transactional
+    public String likeOrUnlikeMemoryPost(Long likedUserId, Long postId) {
+
+        Users likedUser = usersRepository.findById(likedUserId)
+                .orElseThrow(UsersErrorCode.USER_NOT_FOUND::defaultException);
+
+        MemoryPost memoryPost = memoryPostRepository.findById(postId)
+                .orElseThrow(MemoryPostErrorCode.MEMORY_POST_NOT_FOUND::defaultException);
+
+        MemoryPostLike likedInfo = memoryPostLikeRepository.findMemoryPostLikeByLikedUserAndMemoryPost(likedUser, memoryPost);
+
+        String response;
+
+        if (likedInfo == null) {
+            likedInfo = MemoryPostLike.builder()
+                    .likedUser(likedUser)
+                    .memoryPost(memoryPost)
+                    .build();
+
+            memoryPostLikeRepository.save(likedInfo);
+            response = "게시글에 좋아요를 눌렀습니다.";
+        } else {
+            memoryPostLikeRepository.delete(likedInfo);
+            response = "게시글의 좋아요를 취소했습니다.";
+        }
+
+        return response;
+    }
+
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/members/dto/MemoryPostFamilyMembersDto.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/members/dto/MemoryPostFamilyMembersDto.java
@@ -1,0 +1,33 @@
+package com.example.dearfam.domain.memoryposts.members.dto;
+
+import com.example.dearfam.domain.memoryposts.members.entity.MemoryPostFamilyMembers;
+import com.example.dearfam.domain.memoryposts.memorypost.entity.MemoryPost;
+import com.example.dearfam.domain.users.entity.Users;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class MemoryPostFamilyMembersDto {
+    // 일단 만들어두긴 했는데, 필요없으면 삭제해도 됨.
+    private Long id;
+    private MemoryPost memoryPost;
+    private Users joinedFamilyMember;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static MemoryPostFamilyMembersDto from(MemoryPostFamilyMembers memoryPostFamilyMembers) {
+        return MemoryPostFamilyMembersDto.builder()
+                .id(memoryPostFamilyMembers.getId())
+                .memoryPost(memoryPostFamilyMembers.getMemoryPost())
+                .joinedFamilyMember(memoryPostFamilyMembers.getJoinedFamilyMember())
+                .createdAt(memoryPostFamilyMembers.getCreatedAt())
+                .updatedAt(memoryPostFamilyMembers.getUpdatedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/members/dto/MemoryPostFamilyMembersDto.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/members/dto/MemoryPostFamilyMembersDto.java
@@ -8,26 +8,29 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @AllArgsConstructor
 @Builder
 public class MemoryPostFamilyMembersDto {
-    // 일단 만들어두긴 했는데, 필요없으면 삭제해도 됨.
-    private Long id;
-    private MemoryPost memoryPost;
-    private Users joinedFamilyMember;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+
+    private Long familyMemberId;
+    private String nickname;
+    // TODO : 참여한 가족의 프로필 이미지를 건네줘야함
 
     public static MemoryPostFamilyMembersDto from(MemoryPostFamilyMembers memoryPostFamilyMembers) {
         return MemoryPostFamilyMembersDto.builder()
-                .id(memoryPostFamilyMembers.getId())
-                .memoryPost(memoryPostFamilyMembers.getMemoryPost())
-                .joinedFamilyMember(memoryPostFamilyMembers.getJoinedFamilyMember())
-                .createdAt(memoryPostFamilyMembers.getCreatedAt())
-                .updatedAt(memoryPostFamilyMembers.getUpdatedAt())
+                .familyMemberId(memoryPostFamilyMembers.getJoinedFamilyMember().getId())
+                .nickname(memoryPostFamilyMembers.getJoinedFamilyMember().getUserNickname())
                 .build();
+    }
+
+    public static List<MemoryPostFamilyMembersDto> from(List<MemoryPostFamilyMembers> memoryPostFamilyMembers) {
+        return memoryPostFamilyMembers.stream()
+                .map(MemoryPostFamilyMembersDto::from)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/members/entity/MemoryPostFamilyMembers.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/members/entity/MemoryPostFamilyMembers.java
@@ -18,6 +18,7 @@ public class MemoryPostFamilyMembers extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/dearfam/domain/memoryposts/members/entity/MemoryPostFamilyMembers.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/members/entity/MemoryPostFamilyMembers.java
@@ -1,0 +1,37 @@
+package com.example.dearfam.domain.memoryposts.members.entity;
+
+import com.example.dearfam.common.entity.BaseTimeEntity;
+import com.example.dearfam.domain.memoryposts.memorypost.entity.MemoryPost;
+import com.example.dearfam.domain.users.entity.Users;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "memory_post_family_members")
+public class MemoryPostFamilyMembers extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "joined_family_member_id", nullable = false)
+    private Users joinedFamilyMember;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "memory_post_id", nullable = false)
+    private MemoryPost memoryPost;
+
+    @Builder
+    public MemoryPostFamilyMembers(Users joinedFamilyMember, MemoryPost memoryPost) {
+        this.joinedFamilyMember = joinedFamilyMember;
+        this.memoryPost = memoryPost;
+    }
+
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/members/repository/MemoryPostFamilyMembersRepository.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/members/repository/MemoryPostFamilyMembersRepository.java
@@ -1,0 +1,13 @@
+package com.example.dearfam.domain.memoryposts.members.repository;
+
+import com.example.dearfam.domain.memoryposts.members.entity.MemoryPostFamilyMembers;
+import com.example.dearfam.domain.memoryposts.memorypost.entity.MemoryPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MemoryPostFamilyMembersRepository extends JpaRepository<MemoryPostFamilyMembers, Long> {
+    List<MemoryPostFamilyMembers> findAllByMemoryPost(MemoryPost memoryPost);
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/MemoryPostController.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/MemoryPostController.java
@@ -7,6 +7,7 @@ import com.example.dearfam.domain.memoryposts.memorypost.controller.request.Upda
 import com.example.dearfam.domain.memoryposts.memorypost.controller.response.GetMemoryPostFamilyMembersResponse;
 import com.example.dearfam.domain.memoryposts.memorypost.controller.response.GetMemoryPostResponse;
 import com.example.dearfam.domain.memoryposts.memorypost.controller.response.GetUpdatedPostResponse;
+import com.example.dearfam.domain.memoryposts.memorypost.controller.response.*;
 import com.example.dearfam.domain.memoryposts.memorypost.service.MemoryPostService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -124,6 +125,24 @@ public class MemoryPostController {
         Long userId = jwtService.getTokenDto().getUserId();
 
         GetMemoryPostResponse response = memoryPostService.getMemoryPostById(userId, postId);
+
+        return Response.data(response);
+    }
+
+    @Operation(
+            summary = "전체 게시글 조회",
+            description = "시간 순서대로 전체 게시글을 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "404", description = "유저, 가족 정보를 찾을 수 없음."),
+                    @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
+            }
+    )
+    @GetMapping("/time-order")
+    public Response<List<GetAllMemoryPostsResponse>> getAllMemoryPostsByTimeOrder() {
+        Long userId = jwtService.getTokenDto().getUserId();
+
+        List<GetAllMemoryPostsResponse> response = memoryPostService.getAllMemoryPostsByTimeOrder(userId);
 
         return Response.data(response);
     }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/MemoryPostController.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/MemoryPostController.java
@@ -4,9 +4,6 @@ import com.example.dearfam.common.dto.response.Response;
 import com.example.dearfam.common.jwt.auth.JwtService;
 import com.example.dearfam.domain.memoryposts.memorypost.controller.request.CreateMemoryPostRequest;
 import com.example.dearfam.domain.memoryposts.memorypost.controller.request.UpdateMemoryPostRequest;
-import com.example.dearfam.domain.memoryposts.memorypost.controller.response.GetMemoryPostFamilyMembersResponse;
-import com.example.dearfam.domain.memoryposts.memorypost.controller.response.GetMemoryPostResponse;
-import com.example.dearfam.domain.memoryposts.memorypost.controller.response.GetUpdatedPostResponse;
 import com.example.dearfam.domain.memoryposts.memorypost.controller.response.*;
 import com.example.dearfam.domain.memoryposts.memorypost.service.MemoryPostService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -143,6 +140,24 @@ public class MemoryPostController {
         Long userId = jwtService.getTokenDto().getUserId();
 
         List<GetAllMemoryPostsResponse> response = memoryPostService.getAllMemoryPostsByTimeOrder(userId);
+
+        return Response.data(response);
+    }
+
+    @Operation(
+            summary = "최근 게시글 조회",
+            description = "가장 최근 게시글을 최대 10개 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "404", description = "유저, 가족 정보를 찾을 수 없음."),
+                    @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
+            }
+    )
+    @GetMapping("/recent")
+    public Response<List<GetRecentMemoryPostResponse>> getRecentMemoryPosts() {
+        Long userId = jwtService.getTokenDto().getUserId();
+
+        List<GetRecentMemoryPostResponse> response = memoryPostService.getRecentMemoryPosts(userId);
 
         return Response.data(response);
     }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/MemoryPostController.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/MemoryPostController.java
@@ -93,7 +93,12 @@ public class MemoryPostController {
 
     @Operation(
             summary = "게시글 참여 가족 리스트 조회",
-            description = "게시글 ID를 통해 추억 게시글에 참여한 가족들의 ㅁ"
+            description = "게시글 ID를 통해 추억 게시글에 참여한 가족들의 리스트를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "404", description = "MEMORY_POST_NOT_FOUND"),
+                    @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
+            }
     )
     @GetMapping("/{postId}/family-members")
     public Response<GetMemoryPostFamilyMembersResponse> getMemoryPostFamilyMembers(@PathVariable Long postId) {

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/MemoryPostController.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/MemoryPostController.java
@@ -108,4 +108,21 @@ public class MemoryPostController {
         return Response.data(response);
     }
 
+    @Operation(
+            summary = "게시글 단일 조회",
+            description = "게시글 ID를 통해 하나의 게시글을 조회합니다. 현재 로그인한 유저를 기준으로 좋아요 여부를 판단합니다.",
+            responses = {
+
+            }
+    )
+    @GetMapping("/{postId}")
+    public Response<GetMemoryPostResponse> getMemoryPost(@PathVariable Long postId) {
+
+        Long userId = jwtService.getTokenDto().getUserId();
+
+        GetMemoryPostResponse response = memoryPostService.getMemoryPostById(userId, postId);
+
+        return Response.data(response);
+    }
+
 }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/MemoryPostController.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/MemoryPostController.java
@@ -1,0 +1,93 @@
+package com.example.dearfam.domain.memoryposts.memorypost.controller;
+
+import com.example.dearfam.common.dto.response.Response;
+import com.example.dearfam.common.jwt.auth.JwtService;
+import com.example.dearfam.domain.memoryposts.memorypost.controller.request.CreateMemoryPostRequest;
+import com.example.dearfam.domain.memoryposts.memorypost.controller.request.UpdateMemoryPostRequest;
+import com.example.dearfam.domain.memoryposts.memorypost.controller.response.GetMemoryPostResponse;
+import com.example.dearfam.domain.memoryposts.memorypost.controller.response.GetUpdatedPostResponse;
+import com.example.dearfam.domain.memoryposts.memorypost.service.MemoryPostService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/memory-post")
+@Tag(name = "Memory Posts Controller", description = "추억 게시글 관련 기능을 처리하는 API")
+public class MemoryPostController {
+    private final MemoryPostService memoryPostService;
+    private final JwtService jwtService;
+
+    @Operation(
+            summary = "추억 게시글 생성",
+            description = "현재 로그인한 유저가 작성한 추억 게시글을 생성합니다."
+    )
+    @PostMapping
+    public Response<GetMemoryPostResponse> createMemoryPost(@Valid @RequestBody CreateMemoryPostRequest createMemoryPostRequest) {
+        // 로그인한 유저가 게시글을 올리면, writer 는 현재 로그인한 유저임.
+        Long writerId = jwtService.getTokenDto().getUserId();
+        String title = createMemoryPostRequest.getTitle();
+        String content = createMemoryPostRequest.getContent();
+        LocalDate memoryDate = createMemoryPostRequest.getMemoryDate();
+        List<Long> participantFamilyMemberIds = createMemoryPostRequest.getParticipantFamilyMemberIds();
+
+        GetMemoryPostResponse response = memoryPostService.createMemoryPost(
+                writerId,
+                title,
+                content,
+                memoryDate,
+                participantFamilyMemberIds
+                );
+
+        return Response.data(response);
+    }
+
+    @Operation(
+            summary = "추억 게시글 수정",
+            description = "추억 게시글을 수정합니다. 수정 가능사항 : 제목, 내용",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "404", description = "MEMORY_POST_NOT_FOUND"),
+                    @ApiResponse(responseCode = "403", description = "수정 권한이 없음."),
+                    @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR"),
+            }
+    )
+    @PutMapping("/{postId}")
+    public Response<GetUpdatedPostResponse> updateMemoryPost(@PathVariable Long postId,
+                                                             @Valid @RequestBody UpdateMemoryPostRequest updateMemoryPostRequest) {
+        Long writerId = jwtService.getTokenDto().getUserId();
+        String title = updateMemoryPostRequest.getTitle();
+        String content = updateMemoryPostRequest.getContent();
+
+        GetUpdatedPostResponse response = memoryPostService.updateMemoryPost(writerId, postId, title, content);
+
+        return Response.data(response);
+    }
+
+    @Operation(
+            summary = "추억 게시글 삭제",
+            description = "추억 게시글을 삭제합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "404", description = "MEMORY_POST_NOT_FOUND"),
+                    @ApiResponse(responseCode = "403", description = "삭제 권한이 없음."),
+                    @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR"),
+            }
+    )
+    @DeleteMapping("/{postId}")
+    public Response<String> deleteMemoryPost(@PathVariable Long postId) {
+        Long writerId = jwtService.getTokenDto().getUserId();
+
+        memoryPostService.deleteMemoryPost(writerId, postId);
+
+        return Response.data("게시글을 삭제하였습니다.");
+    }
+
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/MemoryPostController.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/MemoryPostController.java
@@ -112,7 +112,10 @@ public class MemoryPostController {
             summary = "게시글 단일 조회",
             description = "게시글 ID를 통해 하나의 게시글을 조회합니다. 현재 로그인한 유저를 기준으로 좋아요 여부를 판단합니다.",
             responses = {
-
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "403", description = "가족이 아닌 사용자는 게시글 접근 권한이 없음."),
+                    @ApiResponse(responseCode = "404", description = "유저, 게시글 정보를 찾을 수 없음."),
+                    @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
             }
     )
     @GetMapping("/{postId}")

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/MemoryPostController.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/MemoryPostController.java
@@ -4,6 +4,7 @@ import com.example.dearfam.common.dto.response.Response;
 import com.example.dearfam.common.jwt.auth.JwtService;
 import com.example.dearfam.domain.memoryposts.memorypost.controller.request.CreateMemoryPostRequest;
 import com.example.dearfam.domain.memoryposts.memorypost.controller.request.UpdateMemoryPostRequest;
+import com.example.dearfam.domain.memoryposts.memorypost.controller.response.GetMemoryPostFamilyMembersResponse;
 import com.example.dearfam.domain.memoryposts.memorypost.controller.response.GetMemoryPostResponse;
 import com.example.dearfam.domain.memoryposts.memorypost.controller.response.GetUpdatedPostResponse;
 import com.example.dearfam.domain.memoryposts.memorypost.service.MemoryPostService;
@@ -88,6 +89,18 @@ public class MemoryPostController {
         memoryPostService.deleteMemoryPost(writerId, postId);
 
         return Response.data("게시글을 삭제하였습니다.");
+    }
+
+    @Operation(
+            summary = "게시글 참여 가족 리스트 조회",
+            description = "게시글 ID를 통해 추억 게시글에 참여한 가족들의 ㅁ"
+    )
+    @GetMapping("/{postId}/family-members")
+    public Response<GetMemoryPostFamilyMembersResponse> getMemoryPostFamilyMembers(@PathVariable Long postId) {
+
+        GetMemoryPostFamilyMembersResponse response = memoryPostService.getMemoryPostFamilyMembers(postId);
+
+        return Response.data(response);
     }
 
 }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/MemoryPostController.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/MemoryPostController.java
@@ -26,7 +26,12 @@ public class MemoryPostController {
 
     @Operation(
             summary = "추억 게시글 생성",
-            description = "현재 로그인한 유저가 작성한 추억 게시글을 생성합니다."
+            description = "현재 로그인한 유저가 작성한 추억 게시글을 생성합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "404", description = "작성자, 가족, 가족 구성원 정보를 찾을 수 없음."),
+                    @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
+            }
     )
     @PostMapping
     public Response<GetMemoryPostResponse> createMemoryPost(@Valid @RequestBody CreateMemoryPostRequest createMemoryPostRequest) {

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/request/CreateMemoryPostRequest.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/request/CreateMemoryPostRequest.java
@@ -1,6 +1,7 @@
 package com.example.dearfam.domain.memoryposts.memorypost.controller.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,7 +19,7 @@ public class CreateMemoryPostRequest {
 
     private String content;
 
-    @NotBlank
+    @NotNull
     private LocalDate memoryDate;
 
     private List<Long> participantFamilyMemberIds;

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/request/CreateMemoryPostRequest.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/request/CreateMemoryPostRequest.java
@@ -1,0 +1,26 @@
+package com.example.dearfam.domain.memoryposts.memorypost.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CreateMemoryPostRequest {
+    // 제목, 내용, 사진, 날짜, 참여가족 id
+    @NotBlank
+    private String title;
+
+    private String content;
+
+    @NotBlank
+    private LocalDate memoryDate;
+
+    private List<Long> participantFamilyMemberIds;
+
+    // TODO : 나중에 사진 엔티티 구성하고, Request 구성하기
+
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/request/CreateMemoryPostRequest.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/request/CreateMemoryPostRequest.java
@@ -3,11 +3,13 @@ package com.example.dearfam.domain.memoryposts.memorypost.controller.request;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.util.List;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class CreateMemoryPostRequest {
     // 제목, 내용, 사진, 날짜, 참여가족 id

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/request/UpdateMemoryPostRequest.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/request/UpdateMemoryPostRequest.java
@@ -1,0 +1,14 @@
+package com.example.dearfam.domain.memoryposts.memorypost.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateMemoryPostRequest {
+    @NotBlank
+    private String title;
+
+    private String content;
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/request/UpdateMemoryPostRequest.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/request/UpdateMemoryPostRequest.java
@@ -3,8 +3,10 @@ package com.example.dearfam.domain.memoryposts.memorypost.controller.request;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class UpdateMemoryPostRequest {
     @NotBlank

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/response/GetAllMemoryPostsResponse.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/response/GetAllMemoryPostsResponse.java
@@ -1,0 +1,39 @@
+package com.example.dearfam.domain.memoryposts.memorypost.controller.response;
+
+import com.example.dearfam.domain.memoryposts.memorypost.dto.SimpleMemoryPostDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@AllArgsConstructor
+@Builder(access = PRIVATE)
+public class GetAllMemoryPostsResponse {
+
+    private int year;
+    private List<SimpleMemoryPostDto> posts;
+
+    public static GetAllMemoryPostsResponse from(int year, List<SimpleMemoryPostDto> posts) {
+        return GetAllMemoryPostsResponse.builder()
+                .year(year)
+                .posts(posts)
+                .build();
+    }
+
+    public static List<GetAllMemoryPostsResponse> from(Map<Integer, List<SimpleMemoryPostDto>> postsGroupedByYear) {
+        return postsGroupedByYear.entrySet().stream()
+                .map(entry -> {
+                    int year = entry.getKey();
+                    List<SimpleMemoryPostDto> posts = entry.getValue();
+                    return GetAllMemoryPostsResponse.from(year, posts);
+                })
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/response/GetMemoryPostFamilyMembersResponse.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/response/GetMemoryPostFamilyMembersResponse.java
@@ -1,5 +1,6 @@
 package com.example.dearfam.domain.memoryposts.memorypost.controller.response;
 
+import com.example.dearfam.domain.memoryposts.memorypost.entity.MemoryPost;
 import com.example.dearfam.domain.users.dto.FamilyMemberDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,11 +15,13 @@ import static lombok.AccessLevel.PRIVATE;
 @Builder(access = PRIVATE)
 public class GetMemoryPostFamilyMembersResponse {
     private Long postId;
+    private Long writerId;
     private List<FamilyMemberDto> participants;
 
-    public static GetMemoryPostFamilyMembersResponse from(Long postId, List<FamilyMemberDto> participants) {
+    public static GetMemoryPostFamilyMembersResponse from(MemoryPost memoryPost, List<FamilyMemberDto> participants) {
         return GetMemoryPostFamilyMembersResponse.builder()
-                .postId(postId)
+                .postId(memoryPost.getId())
+                .writerId(memoryPost.getWriter().getId())
                 .participants(participants)
                 .build();
     }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/response/GetMemoryPostFamilyMembersResponse.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/response/GetMemoryPostFamilyMembersResponse.java
@@ -1,0 +1,25 @@
+package com.example.dearfam.domain.memoryposts.memorypost.controller.response;
+
+import com.example.dearfam.domain.users.dto.FamilyMemberDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@AllArgsConstructor
+@Builder(access = PRIVATE)
+public class GetMemoryPostFamilyMembersResponse {
+    private Long postId;
+    private List<FamilyMemberDto> participants;
+
+    public static GetMemoryPostFamilyMembersResponse from(Long postId, List<FamilyMemberDto> participants) {
+        return GetMemoryPostFamilyMembersResponse.builder()
+                .postId(postId)
+                .participants(participants)
+                .build();
+    }
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/response/GetMemoryPostResponse.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/response/GetMemoryPostResponse.java
@@ -1,5 +1,6 @@
 package com.example.dearfam.domain.memoryposts.memorypost.controller.response;
 
+import com.example.dearfam.domain.memoryposts.members.dto.MemoryPostFamilyMembersDto;
 import com.example.dearfam.domain.memoryposts.memorypost.dto.MemoryPostDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -7,6 +8,7 @@ import lombok.Getter;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static lombok.AccessLevel.PRIVATE;
@@ -15,32 +17,32 @@ import static lombok.AccessLevel.PRIVATE;
 @AllArgsConstructor
 @Builder(access = PRIVATE)
 public class GetMemoryPostResponse {
-
-    private Long postId;
-    private Long familyId;
+    // 게시글을 만들거나  쓴 게시글을 바로 볼 텐데, 그 때 받아야 하는 정보들
     private Long writerId;
     private String title;
     private String content;
     private LocalDate memoryDate;
-//    private List<Long> participantFamilyMemberIds;
+    private List<MemoryPostFamilyMembersDto> participantFamilyMembers;
 
     // TODO : 추후 이미지는 id로 보낼지, 이미지 파일로 보낼지 한 번 고민
 
-    public static GetMemoryPostResponse from(MemoryPostDto memoryPostDto) {
         return GetMemoryPostResponse.builder()
-                .postId(memoryPostDto.getId())
                 .writerId(memoryPostDto.getWriter().getId())
-                .familyId(memoryPostDto.getFamily().getId())
                 .title(memoryPostDto.getMemoryPostsTitle())
                 .content(memoryPostDto.getMemoryPostsContent())
                 .memoryDate(memoryPostDto.getMemoryDate())
-                // TODO : 이건 나중에 그 참여 가족 엔티티 구성하고, dto 추가해서 구현
+                .participantFamilyMembers(participantFamilyMembers)
                 .build();
     }
 
-    public static List<GetMemoryPostResponse> from(List<MemoryPostDto> memoryPostDtos) {
-        return memoryPostDtos.stream()
-                .map(GetMemoryPostResponse::from)
+    public static List<GetMemoryPostResponse> from(List<MemoryPostDto> memoryPosts,
+                                                   Map<Long, List<MemoryPostFamilyMembersDto>> memoryPostFamilyMembers,
+        return memoryPosts.stream()
+                .map(dto -> GetMemoryPostResponse.from(
+                        dto,
+                        memoryPostFamilyMembers.getOrDefault(dto.getId(), List.of()),
+                ))
                 .collect(Collectors.toList());
     }
+
 }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/response/GetMemoryPostResponse.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/response/GetMemoryPostResponse.java
@@ -1,0 +1,46 @@
+package com.example.dearfam.domain.memoryposts.memorypost.controller.response;
+
+import com.example.dearfam.domain.memoryposts.memorypost.dto.MemoryPostDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@AllArgsConstructor
+@Builder(access = PRIVATE)
+public class GetMemoryPostResponse {
+
+    private Long postId;
+    private Long familyId;
+    private Long writerId;
+    private String title;
+    private String content;
+    private LocalDate memoryDate;
+//    private List<Long> participantFamilyMemberIds;
+
+    // TODO : 추후 이미지는 id로 보낼지, 이미지 파일로 보낼지 한 번 고민
+
+    public static GetMemoryPostResponse from(MemoryPostDto memoryPostDto) {
+        return GetMemoryPostResponse.builder()
+                .postId(memoryPostDto.getId())
+                .writerId(memoryPostDto.getWriter().getId())
+                .familyId(memoryPostDto.getFamily().getId())
+                .title(memoryPostDto.getMemoryPostsTitle())
+                .content(memoryPostDto.getMemoryPostsContent())
+                .memoryDate(memoryPostDto.getMemoryDate())
+                // TODO : 이건 나중에 그 참여 가족 엔티티 구성하고, dto 추가해서 구현
+                .build();
+    }
+
+    public static List<GetMemoryPostResponse> from(List<MemoryPostDto> memoryPostDtos) {
+        return memoryPostDtos.stream()
+                .map(GetMemoryPostResponse::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/response/GetMemoryPostResponse.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/response/GetMemoryPostResponse.java
@@ -22,25 +22,30 @@ public class GetMemoryPostResponse {
     private String title;
     private String content;
     private LocalDate memoryDate;
+    private boolean isLiked;
     private List<MemoryPostFamilyMembersDto> participantFamilyMembers;
 
     // TODO : 추후 이미지는 id로 보낼지, 이미지 파일로 보낼지 한 번 고민
 
+    public static GetMemoryPostResponse from(MemoryPostDto memoryPostDto, List<MemoryPostFamilyMembersDto> participantFamilyMembers, boolean isLiked) {
         return GetMemoryPostResponse.builder()
                 .writerId(memoryPostDto.getWriter().getId())
                 .title(memoryPostDto.getMemoryPostsTitle())
                 .content(memoryPostDto.getMemoryPostsContent())
                 .memoryDate(memoryPostDto.getMemoryDate())
+                .isLiked(isLiked)
                 .participantFamilyMembers(participantFamilyMembers)
                 .build();
     }
 
     public static List<GetMemoryPostResponse> from(List<MemoryPostDto> memoryPosts,
                                                    Map<Long, List<MemoryPostFamilyMembersDto>> memoryPostFamilyMembers,
+                                                   Map<Long, Boolean> isLikedList) {
         return memoryPosts.stream()
                 .map(dto -> GetMemoryPostResponse.from(
                         dto,
                         memoryPostFamilyMembers.getOrDefault(dto.getId(), List.of()),
+                        isLikedList.getOrDefault(dto.getId(), false)
                 ))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/response/GetMemoryPostResponse.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/response/GetMemoryPostResponse.java
@@ -27,27 +27,17 @@ public class GetMemoryPostResponse {
 
     // TODO : 추후 이미지는 id로 보낼지, 이미지 파일로 보낼지 한 번 고민
 
-    public static GetMemoryPostResponse from(MemoryPostDto memoryPostDto, List<MemoryPostFamilyMembersDto> participantFamilyMembers, boolean isLiked) {
+    public static GetMemoryPostResponse from(MemoryPostDto memoryPostDto,
+                                             List<MemoryPostFamilyMembersDto> participantFamilyMembers,
+                                             boolean isLiked) {
         return GetMemoryPostResponse.builder()
                 .writerId(memoryPostDto.getWriter().getId())
-                .title(memoryPostDto.getMemoryPostsTitle())
-                .content(memoryPostDto.getMemoryPostsContent())
+                .title(memoryPostDto.getMemoryPostTitle())
+                .content(memoryPostDto.getMemoryPostContent())
                 .memoryDate(memoryPostDto.getMemoryDate())
                 .isLiked(isLiked)
                 .participantFamilyMembers(participantFamilyMembers)
                 .build();
-    }
-
-    public static List<GetMemoryPostResponse> from(List<MemoryPostDto> memoryPosts,
-                                                   Map<Long, List<MemoryPostFamilyMembersDto>> memoryPostFamilyMembers,
-                                                   Map<Long, Boolean> isLikedList) {
-        return memoryPosts.stream()
-                .map(dto -> GetMemoryPostResponse.from(
-                        dto,
-                        memoryPostFamilyMembers.getOrDefault(dto.getId(), List.of()),
-                        isLikedList.getOrDefault(dto.getId(), false)
-                ))
-                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/response/GetRecentMemoryPostResponse.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/response/GetRecentMemoryPostResponse.java
@@ -1,0 +1,58 @@
+package com.example.dearfam.domain.memoryposts.memorypost.controller.response;
+
+import com.example.dearfam.domain.memoryposts.members.dto.MemoryPostFamilyMembersDto;
+import com.example.dearfam.domain.memoryposts.memorypost.dto.MemoryPostDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@AllArgsConstructor
+@Builder(access = PRIVATE)
+public class GetRecentMemoryPostResponse {
+    // 응답으로 넘겨야 하는 정보 : 게시글의 첫 번째 이미지, 제목, 내용, 게시글 참여 가족 구성원 리스트, 좋아요 여부, 댓글 수
+    // TODO : 이미지 처리 해야함.
+
+    private Long postId;
+    private String title;
+    private String content;
+    private Integer commentCount;
+    private LocalDate memoryDate;
+    private boolean isLiked;
+    private List<MemoryPostFamilyMembersDto> participants;
+
+    public static GetRecentMemoryPostResponse from(MemoryPostDto memoryPostDto,
+                                                   List<MemoryPostFamilyMembersDto> participants,
+                                                   boolean isLiked) {
+        return GetRecentMemoryPostResponse.builder()
+                .postId(memoryPostDto.getId())
+                .title(memoryPostDto.getMemoryPostTitle())
+                .content(memoryPostDto.getMemoryPostContent())
+                .commentCount(memoryPostDto.getMemoryPostCommentCount())
+                .memoryDate(memoryPostDto.getMemoryDate())
+                .isLiked(isLiked)
+                .participants(participants)
+                .build();
+    }
+
+    public static List<GetRecentMemoryPostResponse> from(List<MemoryPostDto> memoryPostDtoList,
+                                                         Map<Long, List<MemoryPostFamilyMembersDto>> participantsList,
+                                                         Map<Long, Boolean> isLikedList) {
+        return memoryPostDtoList.stream()
+                .map(postDto -> GetRecentMemoryPostResponse.from(
+                        postDto,
+                        participantsList.getOrDefault(postDto.getId(), List.of()),
+                        isLikedList.get(postDto.getId())
+                ))
+                .collect(Collectors.toList());
+    }
+
+
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/response/GetUpdatedPostResponse.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/response/GetUpdatedPostResponse.java
@@ -1,0 +1,24 @@
+package com.example.dearfam.domain.memoryposts.memorypost.controller.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@AllArgsConstructor
+@Builder(access = PRIVATE)
+public class GetUpdatedPostResponse {
+    private Long postId;
+    private String title;
+    private String content;
+
+    public static GetUpdatedPostResponse from(Long postId, String title, String content) {
+        return GetUpdatedPostResponse.builder()
+                .postId(postId)
+                .title(title)
+                .content(content)
+                .build();
+    }
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/dto/MemoryPostDto.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/dto/MemoryPostDto.java
@@ -19,9 +19,9 @@ public class MemoryPostDto {
     private Long id;
     private Family family;
     private Users writer;
-    private String memoryPostsTitle;
-    private String memoryPostsContent;
-    private Integer memoryPostsCommentCount;
+    private String memoryPostTitle;
+    private String memoryPostContent;
+    private Integer memoryPostCommentCount;
     private Integer memoryPostImageCount;
     private LocalDate memoryDate;
     private LocalDateTime createdAt;
@@ -32,9 +32,9 @@ public class MemoryPostDto {
                 .id(memoryPost.getId())
                 .family(memoryPost.getFamily())
                 .writer(memoryPost.getWriter())
-                .memoryPostsTitle(memoryPost.getMemoryPostTitle())
-                .memoryPostsContent(memoryPost.getMemoryPostContent())
-                .memoryPostsCommentCount(memoryPost.getMemoryPostCommentCount())
+                .memoryPostTitle(memoryPost.getMemoryPostTitle())
+                .memoryPostContent(memoryPost.getMemoryPostContent())
+                .memoryPostCommentCount(memoryPost.getMemoryPostCommentCount())
                 .memoryPostImageCount(memoryPost.getMemoryPostImageCount())
                 .memoryDate(memoryPost.getMemoryDate())
                 .createdAt(memoryPost.getCreatedAt())

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/dto/MemoryPostDto.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/dto/MemoryPostDto.java
@@ -1,0 +1,51 @@
+package com.example.dearfam.domain.memoryposts.memorypost.dto;
+
+import com.example.dearfam.domain.family.entity.Family;
+import com.example.dearfam.domain.memoryposts.memorypost.entity.MemoryPost;
+import com.example.dearfam.domain.users.entity.Users;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class MemoryPostDto {
+    private Long id;
+    private Family family;
+    private Users writer;
+    private String memoryPostsTitle;
+    private String memoryPostsContent;
+    private Integer memoryPostsCommentCount;
+    private Integer memoryPostImageCount;
+    private LocalDate memoryDate;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static MemoryPostDto from(MemoryPost memoryPost) {
+        return MemoryPostDto.builder()
+                .id(memoryPost.getId())
+                .family(memoryPost.getFamily())
+                .writer(memoryPost.getWriter())
+                .memoryPostsTitle(memoryPost.getMemoryPostTitle())
+                .memoryPostsContent(memoryPost.getMemoryPostContent())
+                .memoryPostsCommentCount(memoryPost.getMemoryPostCommentCount())
+                .memoryPostImageCount(memoryPost.getMemoryPostImageCount())
+                .memoryDate(memoryPost.getMemoryDate())
+                .createdAt(memoryPost.getCreatedAt())
+                .updatedAt(memoryPost.getUpdatedAt())
+                .build();
+    }
+
+    public static List<MemoryPostDto> from(List<MemoryPost> memoryPostList) {
+        return memoryPostList.stream()
+                .map(MemoryPostDto::from)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/dto/SimpleMemoryPostDto.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/dto/SimpleMemoryPostDto.java
@@ -1,0 +1,32 @@
+package com.example.dearfam.domain.memoryposts.memorypost.dto;
+
+import com.example.dearfam.domain.memoryposts.memorypost.entity.MemoryPost;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class SimpleMemoryPostDto {
+    private Long postId;
+    private LocalDate memoryDate;
+//    private String imageUrl;
+
+    public static SimpleMemoryPostDto from(MemoryPost memoryPost) {
+        return SimpleMemoryPostDto.builder()
+                .postId(memoryPost.getId())
+                .memoryDate(memoryPost.getMemoryDate())
+                .build();
+    }
+
+    public static List<SimpleMemoryPostDto> from(List<MemoryPost> memoryPosts) {
+        return memoryPosts.stream().
+                map(SimpleMemoryPostDto::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/entity/MemoryPost.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/entity/MemoryPost.java
@@ -1,0 +1,63 @@
+package com.example.dearfam.domain.memoryposts.memorypost.entity;
+
+import com.example.dearfam.common.entity.BaseTimeEntity;
+import com.example.dearfam.domain.family.entity.Family;
+import com.example.dearfam.domain.users.entity.Users;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "memory_post")
+public class MemoryPost extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "memory_post_id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "family_id", nullable = false)
+    private Family family;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id", nullable = false)
+    private Users writer;
+
+    @Column(name = "memory_post_title", nullable = false, length = 50)
+    private String memoryPostTitle;
+
+    @Column(name = "memory_post_content", nullable = false, length = 500)
+    private String memoryPostContent;
+
+    @Column(name = "memory_post_comment_count", nullable = false)
+    private Integer memoryPostCommentCount;
+
+    @Column(name = "memory_post_image_count", nullable = false)
+    private Integer memoryPostImageCount;
+
+    @Column(name = "memory_date", nullable = false)
+    private LocalDate memoryDate;
+
+    // TODO : 이미지 엔티티 만들고, OneToMany 로 추가하기
+
+    @Builder
+    public MemoryPost(Family family, Users writer, String memoryPostTitle, String memoryPostContent, Integer memoryPostCommentCount,
+                      Integer memoryPostImageCount, LocalDate memoryDate) {
+        this.family = family;
+        this.writer = writer;
+        this.memoryPostTitle = memoryPostTitle;
+        this.memoryPostContent = memoryPostContent;
+        this.memoryPostCommentCount = memoryPostCommentCount == null ? 0 : memoryPostCommentCount;
+        this.memoryPostImageCount = memoryPostImageCount == null ? 0 : memoryPostImageCount;
+        this.memoryDate = memoryDate;
+    }
+
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/entity/MemoryPost.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/entity/MemoryPost.java
@@ -3,6 +3,7 @@ package com.example.dearfam.domain.memoryposts.memorypost.entity;
 import com.example.dearfam.common.entity.BaseTimeEntity;
 import com.example.dearfam.domain.family.entity.Family;
 import com.example.dearfam.domain.memoryposts.comment.entity.MemoryPostComment;
+import com.example.dearfam.domain.memoryposts.like.entity.MemoryPostLike;
 import com.example.dearfam.domain.users.entity.Users;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -53,6 +54,9 @@ public class MemoryPost extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "memoryPost", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemoryPostComment> memoryPostComments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "memoryPost", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MemoryPostLike> memoryPostLikes = new ArrayList<>();
 
     @Builder
     public MemoryPost(Family family, Users writer, String memoryPostTitle, String memoryPostContent, Integer memoryPostCommentCount,

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/entity/MemoryPost.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/entity/MemoryPost.java
@@ -4,6 +4,7 @@ import com.example.dearfam.common.entity.BaseTimeEntity;
 import com.example.dearfam.domain.family.entity.Family;
 import com.example.dearfam.domain.memoryposts.comment.entity.MemoryPostComment;
 import com.example.dearfam.domain.memoryposts.like.entity.MemoryPostLike;
+import com.example.dearfam.domain.memoryposts.members.entity.MemoryPostFamilyMembers;
 import com.example.dearfam.domain.users.entity.Users;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -57,6 +58,9 @@ public class MemoryPost extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "memoryPost", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemoryPostLike> memoryPostLikes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "memoryPost", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MemoryPostFamilyMembers> memoryPostFamilyMembers = new ArrayList<>();
 
     @Builder
     public MemoryPost(Family family, Users writer, String memoryPostTitle, String memoryPostContent, Integer memoryPostCommentCount,

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/entity/MemoryPost.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/entity/MemoryPost.java
@@ -2,6 +2,7 @@ package com.example.dearfam.domain.memoryposts.memorypost.entity;
 
 import com.example.dearfam.common.entity.BaseTimeEntity;
 import com.example.dearfam.domain.family.entity.Family;
+import com.example.dearfam.domain.memoryposts.comment.entity.MemoryPostComment;
 import com.example.dearfam.domain.users.entity.Users;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -10,6 +11,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Setter
@@ -47,6 +50,9 @@ public class MemoryPost extends BaseTimeEntity {
     private LocalDate memoryDate;
 
     // TODO : 이미지 엔티티 만들고, OneToMany 로 추가하기
+
+    @OneToMany(mappedBy = "memoryPost", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MemoryPostComment> memoryPostComments = new ArrayList<>();
 
     @Builder
     public MemoryPost(Family family, Users writer, String memoryPostTitle, String memoryPostContent, Integer memoryPostCommentCount,

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/exception/MemoryPostErrorCode.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/exception/MemoryPostErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 public enum MemoryPostErrorCode implements ErrorCode {
     MEMORY_POST_NOT_FOUND("추억 게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     UNAUTHORIZED_MEMORY_POST_ACCESS("게시글 작성자만 수정 또는 삭제가 가능합니다.", HttpStatus.FORBIDDEN),
+    UNAUTHORIZED_FAMILY_ACCESS("같은 가족끼리만 접근이 가능합니다.", HttpStatus.FORBIDDEN),
     DEFAULT("추억 게시글 처리 중 문제가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String message;

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/exception/MemoryPostErrorCode.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/exception/MemoryPostErrorCode.java
@@ -1,0 +1,35 @@
+package com.example.dearfam.domain.memoryposts.memorypost.exception;
+
+import com.example.dearfam.common.exception.errorcode.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum MemoryPostErrorCode implements ErrorCode {
+    MEMORY_POST_NOT_FOUND("추억 게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    UNAUTHORIZED_MEMORY_POST_ACCESS("게시글 작성자만 수정 또는 삭제가 가능합니다.", HttpStatus.FORBIDDEN),
+    DEFAULT("추억 게시글 처리 중 문제가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final String message;
+    private final HttpStatus status;
+
+    @Override
+    public HttpStatus defaultHttpStatus() {
+        return status;
+    }
+
+    @Override
+    public String defaultMessage() {
+        return message;
+    }
+
+    @Override
+    public MemoryPostException defaultException() {
+        return new MemoryPostException(this);
+    }
+
+    @Override
+    public MemoryPostException defaultException(Throwable cause) {
+        return new MemoryPostException(this, cause);
+    }
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/exception/MemoryPostException.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/exception/MemoryPostException.java
@@ -1,0 +1,26 @@
+package com.example.dearfam.domain.memoryposts.memorypost.exception;
+
+import com.example.dearfam.common.exception.CustomException;
+import com.example.dearfam.common.exception.errorcode.ErrorCode;
+
+public class MemoryPostException extends CustomException {
+    public MemoryPostException() {
+        super();
+    }
+
+    public MemoryPostException(String message) {
+        super(message);
+    }
+
+    public MemoryPostException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public MemoryPostException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public MemoryPostException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/repository/MemoryPostRepository.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/repository/MemoryPostRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemoryPostRepository extends JpaRepository<MemoryPost, Long> {
+    List<MemoryPost> findAllByFamilyOrderByMemoryDateDesc(Family family);
 }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/repository/MemoryPostRepository.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/repository/MemoryPostRepository.java
@@ -2,6 +2,8 @@ package com.example.dearfam.domain.memoryposts.memorypost.repository;
 
 import com.example.dearfam.domain.memoryposts.memorypost.entity.MemoryPost;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface MemoryPostRepository extends JpaRepository<MemoryPost, Long> {
 }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/repository/MemoryPostRepository.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/repository/MemoryPostRepository.java
@@ -1,0 +1,7 @@
+package com.example.dearfam.domain.memoryposts.memorypost.repository;
+
+import com.example.dearfam.domain.memoryposts.memorypost.entity.MemoryPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemoryPostRepository extends JpaRepository<MemoryPost, Long> {
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/repository/MemoryPostRepository.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/repository/MemoryPostRepository.java
@@ -1,10 +1,14 @@
 package com.example.dearfam.domain.memoryposts.memorypost.repository;
 
+import com.example.dearfam.domain.family.entity.Family;
 import com.example.dearfam.domain.memoryposts.memorypost.entity.MemoryPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface MemoryPostRepository extends JpaRepository<MemoryPost, Long> {
     List<MemoryPost> findAllByFamilyOrderByMemoryDateDesc(Family family);
+    List<MemoryPost> findTop10ByFamilyOrderByMemoryDateDesc(Family family);
 }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
@@ -3,6 +3,8 @@ package com.example.dearfam.domain.memoryposts.memorypost.service;
 import com.example.dearfam.common.entity.BaseTimeEntity;
 import com.example.dearfam.domain.family.entity.Family;
 import com.example.dearfam.domain.family.exception.FamilyErrorCode;
+import com.example.dearfam.domain.memoryposts.like.repository.MemoryPostLikeRepository;
+import com.example.dearfam.domain.memoryposts.members.dto.MemoryPostFamilyMembersDto;
 import com.example.dearfam.domain.memoryposts.members.entity.MemoryPostFamilyMembers;
 import com.example.dearfam.domain.memoryposts.members.repository.MemoryPostFamilyMembersRepository;
 import com.example.dearfam.domain.memoryposts.memorypost.controller.response.GetMemoryPostFamilyMembersResponse;
@@ -47,6 +49,8 @@ public class MemoryPostService {
             throw FamilyErrorCode.FAMILY_NOT_FOUND.defaultException();
         }
 
+        // TODO : 추후 이미지 저장 로직 여기서 추가 구현 후 memoryPostRepository save 하는 순서가 맞음.
+
         MemoryPost memoryPost = MemoryPost.builder()
                 .writer(writer)
                 .family(family)
@@ -55,7 +59,10 @@ public class MemoryPostService {
                 .memoryDate(memoryDate)
                 .build();
 
+        // 생성한 게시글 저장
         memoryPostRepository.save(memoryPost);
+
+        List<MemoryPostFamilyMembers> memoryPostFamilyMembers = List.of();
 
         if (participantFamilyMemberIds != null && !participantFamilyMemberIds.isEmpty()) {
             // 현재 가족 구성원 조회
@@ -66,7 +73,7 @@ public class MemoryPostService {
                     .collect(Collectors.toMap(Users::getId, Function.identity()));
 
             // 참여 가족 id를 통해 현재 가족 구성원에서 참여한 가족의 객체를 맵핑하고, MemoryPostFamilyMembers 객체를 빌드한다.
-            List<MemoryPostFamilyMembers> memoryPostFamilyMembers = participantFamilyMemberIds.stream()
+            memoryPostFamilyMembers = participantFamilyMemberIds.stream()
                     .filter(id -> !id.equals(writerId)) // 작성자는 제외
                     .map(id -> {
                         Users user = familyMemberMap.get(id);
@@ -80,14 +87,14 @@ public class MemoryPostService {
                     })
                     .toList();
 
+            // 게시글에 참여한 가족 구성원 저장
             memoryPostFamilyMembersRepository.saveAll(memoryPostFamilyMembers);
         }
 
-        // TODO : 추후 이미지 저장 로직 여기서 추가 구현
-
         MemoryPostDto memoryPostDto = MemoryPostDto.from(memoryPost);
 
-        return GetMemoryPostResponse.from(memoryPostDto);
+        List<MemoryPostFamilyMembersDto> membersDtos = MemoryPostFamilyMembersDto.from(memoryPostFamilyMembers);
+
     }
 
     @Transactional

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
@@ -1,16 +1,16 @@
 package com.example.dearfam.domain.memoryposts.memorypost.service;
 
 import com.example.dearfam.common.entity.BaseTimeEntity;
+import com.example.dearfam.common.jwt.auth.JwtService;
 import com.example.dearfam.domain.family.entity.Family;
 import com.example.dearfam.domain.family.exception.FamilyErrorCode;
 import com.example.dearfam.domain.memoryposts.like.repository.MemoryPostLikeRepository;
 import com.example.dearfam.domain.memoryposts.members.dto.MemoryPostFamilyMembersDto;
 import com.example.dearfam.domain.memoryposts.members.entity.MemoryPostFamilyMembers;
 import com.example.dearfam.domain.memoryposts.members.repository.MemoryPostFamilyMembersRepository;
-import com.example.dearfam.domain.memoryposts.memorypost.controller.response.GetMemoryPostFamilyMembersResponse;
-import com.example.dearfam.domain.memoryposts.memorypost.controller.response.GetMemoryPostResponse;
-import com.example.dearfam.domain.memoryposts.memorypost.controller.response.GetUpdatedPostResponse;
+import com.example.dearfam.domain.memoryposts.memorypost.controller.response.*;
 import com.example.dearfam.domain.memoryposts.memorypost.dto.MemoryPostDto;
+import com.example.dearfam.domain.memoryposts.memorypost.dto.SimpleMemoryPostDto;
 import com.example.dearfam.domain.memoryposts.memorypost.entity.MemoryPost;
 import com.example.dearfam.domain.memoryposts.memorypost.exception.MemoryPostErrorCode;
 import com.example.dearfam.domain.memoryposts.memorypost.repository.MemoryPostRepository;
@@ -24,9 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -206,4 +204,33 @@ public class MemoryPostService {
 
     @Transactional(readOnly = true)
     public List<GetRecentMemoryPostResponse> getRecentMemoryPosts(Long userId) {
+
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(UsersErrorCode.USER_NOT_FOUND::defaultException);
+
+        Family family = user.getFamily();
+        if (family == null) {
+            throw FamilyErrorCode.FAMILY_NOT_FOUND.defaultException();
+        }
+
+        // memoryDate 기준 최근 10개의 데이터를 가져옴
+        List<MemoryPost> memoryPosts  = memoryPostRepository.findTop10ByFamilyOrderByMemoryDateDesc(family);
+        List<MemoryPostDto> memoryPostDtoList = MemoryPostDto.from(memoryPosts);
+
+        Map<Long, List<MemoryPostFamilyMembersDto>> participantsList = new HashMap<>();
+        Map<Long, Boolean> isLikedList = new HashMap<>();
+        for (MemoryPost memoryPost : memoryPosts) {
+            // 참여 가족 구성원 맵핑
+            List<MemoryPostFamilyMembers> members = memoryPostFamilyMembersRepository.findAllByMemoryPost(memoryPost);
+            List<MemoryPostFamilyMembersDto> memberDtoList = MemoryPostFamilyMembersDto.from(members);
+            participantsList.put(memoryPost.getId(), memberDtoList);
+
+            // 좋아요 여부 맵핑
+            boolean isLiked = memoryPostLikeRepository.existsByLikedUserAndMemoryPost(user, memoryPost);
+            isLikedList.put(memoryPost.getId(), isLiked);
+        }
+
+        return  GetRecentMemoryPostResponse.from(memoryPostDtoList, participantsList, isLikedList);
+    }
+
 }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
@@ -107,7 +107,7 @@ public class MemoryPostService {
                 .orElseThrow(MemoryPostErrorCode.MEMORY_POST_NOT_FOUND::defaultException);
 
         if (!memoryPost.getWriter().getId().equals(writerId)) {
-            throw MemoryPostErrorCode.MEMORY_POST_NOT_FOUND.defaultException();
+            throw MemoryPostErrorCode.UNAUTHORIZED_MEMORY_POST_ACCESS.defaultException();
         }
 
         memoryPost.setMemoryPostTitle(title);

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
@@ -36,6 +36,7 @@ public class MemoryPostService {
     private final UsersRepository usersRepository;
     private final MemoryPostRepository memoryPostRepository;
     private final MemoryPostFamilyMembersRepository memoryPostFamilyMembersRepository;
+    private final MemoryPostLikeRepository memoryPostLikeRepository;
 
     @Transactional
     public GetMemoryPostResponse createMemoryPost(Long writerId, String title, String content,
@@ -95,6 +96,9 @@ public class MemoryPostService {
 
         List<MemoryPostFamilyMembersDto> membersDtos = MemoryPostFamilyMembersDto.from(memoryPostFamilyMembers);
 
+        boolean isLiked = memoryPostLikeRepository.existsByLikedUserAndMemoryPost(writer, memoryPost);
+
+        return GetMemoryPostResponse.from(memoryPostDto, membersDtos, isLiked);
     }
 
     @Transactional

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
@@ -67,6 +67,7 @@ public class MemoryPostService {
 
             // 참여 가족 id를 통해 현재 가족 구성원에서 참여한 가족의 객체를 맵핑하고, MemoryPostFamilyMembers 객체를 빌드한다.
             List<MemoryPostFamilyMembers> memoryPostFamilyMembers = participantFamilyMemberIds.stream()
+                    .filter(id -> !id.equals(writerId)) // 작성자는 제외
                     .map(id -> {
                         Users user = familyMemberMap.get(id);
                         if (user == null) {
@@ -115,7 +116,7 @@ public class MemoryPostService {
                 .orElseThrow(MemoryPostErrorCode.MEMORY_POST_NOT_FOUND::defaultException);
 
         if (!memoryPost.getWriter().getId().equals(writerId)) {
-            throw MemoryPostErrorCode.MEMORY_POST_NOT_FOUND.defaultException();
+            throw MemoryPostErrorCode.UNAUTHORIZED_MEMORY_POST_ACCESS.defaultException();
         }
         memoryPostRepository.delete(memoryPost);
     }
@@ -139,7 +140,7 @@ public class MemoryPostService {
                 .toList();
 
 
-        return GetMemoryPostFamilyMembersResponse.from(postId, participants);
+        return GetMemoryPostFamilyMembersResponse.from(post, participants);
     }
 
 }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
@@ -35,7 +35,6 @@ public class MemoryPostService {
     private final MemoryPostRepository memoryPostRepository;
     private final MemoryPostFamilyMembersRepository memoryPostFamilyMembersRepository;
     private final MemoryPostLikeRepository memoryPostLikeRepository;
-    private final JwtService jwtService;
 
     @Transactional
     public GetMemoryPostResponse createMemoryPost(Long writerId, String title, String content,

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
@@ -11,9 +11,9 @@ import com.example.dearfam.domain.memoryposts.memorypost.repository.MemoryPostRe
 import com.example.dearfam.domain.users.entity.Users;
 import com.example.dearfam.domain.users.exception.UsersErrorCode;
 import com.example.dearfam.domain.users.repository.UsersRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
@@ -154,4 +154,29 @@ public class MemoryPostService {
         return GetMemoryPostFamilyMembersResponse.from(post, participants);
     }
 
+    @Transactional(readOnly = true)
+    public GetMemoryPostResponse getMemoryPostById(Long userId, Long postId) {
+
+        MemoryPost memoryPost = memoryPostRepository.findById(postId)
+                .orElseThrow(MemoryPostErrorCode.MEMORY_POST_NOT_FOUND::defaultException);
+
+        MemoryPostDto memoryPostDto = MemoryPostDto.from(memoryPost);
+
+        List<MemoryPostFamilyMembers> familyMembers = memoryPostFamilyMembersRepository.findAllByMemoryPost(memoryPost);
+        List<MemoryPostFamilyMembersDto> participants = MemoryPostFamilyMembersDto.from(familyMembers);
+
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(UsersErrorCode.USER_NOT_FOUND::defaultException);
+
+        // 로그인한 사용자의 가족이 아닌 경우에는 접근 불가
+        if (!memoryPost.getFamily().getId().equals(user.getFamily().getId())) {
+            throw MemoryPostErrorCode.UNAUTHORIZED_FAMILY_ACCESS.defaultException();
+        }
+
+        boolean isLiked = memoryPostLikeRepository.existsByLikedUserAndMemoryPost(user, memoryPost);
+
+        return GetMemoryPostResponse.from(memoryPostDto, participants, isLiked);
+    }
+
+
 }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
@@ -37,6 +37,7 @@ public class MemoryPostService {
     private final MemoryPostRepository memoryPostRepository;
     private final MemoryPostFamilyMembersRepository memoryPostFamilyMembersRepository;
     private final MemoryPostLikeRepository memoryPostLikeRepository;
+    private final JwtService jwtService;
 
     @Transactional
     public GetMemoryPostResponse createMemoryPost(Long writerId, String title, String content,
@@ -179,4 +180,30 @@ public class MemoryPostService {
     }
 
 
+    @Transactional(readOnly = true)
+    public List<GetAllMemoryPostsResponse> getAllMemoryPostsByTimeOrder(Long userId) {
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(UsersErrorCode.USER_NOT_FOUND::defaultException);
+
+        Family family = user.getFamily();
+        if (family == null) {
+            throw FamilyErrorCode.FAMILY_NOT_FOUND.defaultException();
+        }
+
+        List<MemoryPost> memoryPosts = memoryPostRepository.findAllByFamilyOrderByMemoryDateDesc(family);
+        List<SimpleMemoryPostDto> posts = SimpleMemoryPostDto.from(memoryPosts);
+
+        Map<Integer, List<SimpleMemoryPostDto>> postsGroupedByYear = new TreeMap<>(Comparator.reverseOrder());
+
+        for (SimpleMemoryPostDto memoryPost : posts) {
+            if (memoryPost.getMemoryDate() == null) continue;
+            int year = memoryPost.getMemoryDate().getYear();
+            postsGroupedByYear.computeIfAbsent(year, k -> new ArrayList<>()).add(memoryPost);
+        }
+
+        return GetAllMemoryPostsResponse.from(postsGroupedByYear);
+    }
+
+    @Transactional(readOnly = true)
+    public List<GetRecentMemoryPostResponse> getRecentMemoryPosts(Long userId) {
 }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
@@ -1,13 +1,19 @@
 package com.example.dearfam.domain.memoryposts.memorypost.service;
 
+import com.example.dearfam.common.entity.BaseTimeEntity;
 import com.example.dearfam.domain.family.entity.Family;
 import com.example.dearfam.domain.family.exception.FamilyErrorCode;
+import com.example.dearfam.domain.memoryposts.members.entity.MemoryPostFamilyMembers;
+import com.example.dearfam.domain.memoryposts.members.repository.MemoryPostFamilyMembersRepository;
+import com.example.dearfam.domain.memoryposts.memorypost.controller.response.GetMemoryPostFamilyMembersResponse;
 import com.example.dearfam.domain.memoryposts.memorypost.controller.response.GetMemoryPostResponse;
 import com.example.dearfam.domain.memoryposts.memorypost.controller.response.GetUpdatedPostResponse;
 import com.example.dearfam.domain.memoryposts.memorypost.dto.MemoryPostDto;
 import com.example.dearfam.domain.memoryposts.memorypost.entity.MemoryPost;
 import com.example.dearfam.domain.memoryposts.memorypost.exception.MemoryPostErrorCode;
 import com.example.dearfam.domain.memoryposts.memorypost.repository.MemoryPostRepository;
+import com.example.dearfam.domain.users.dto.FamilyMemberDto;
+import com.example.dearfam.domain.users.entity.UserFamilyRole;
 import com.example.dearfam.domain.users.entity.Users;
 import com.example.dearfam.domain.users.exception.UsersErrorCode;
 import com.example.dearfam.domain.users.repository.UsersRepository;
@@ -16,13 +22,18 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class MemoryPostService {
     private final UsersRepository usersRepository;
     private final MemoryPostRepository memoryPostRepository;
+    private final MemoryPostFamilyMembersRepository memoryPostFamilyMembersRepository;
 
     @Transactional
     public GetMemoryPostResponse createMemoryPost(Long writerId, String title, String content,
@@ -46,7 +57,32 @@ public class MemoryPostService {
 
         memoryPostRepository.save(memoryPost);
 
-        // TODO : 추후 참여자, 이미지 저장 로직 여기서 추가 구현
+        if (participantFamilyMemberIds != null && !participantFamilyMemberIds.isEmpty()) {
+            // 현재 가족 구성원 조회
+            List<Users> familyMembers = usersRepository.findAllByFamilyId(family.getId());
+
+            // 가족 구성원을 Map으로 <id, id에 대한 Users 객체> 로 구성
+            Map<Long, Users> familyMemberMap = familyMembers.stream()
+                    .collect(Collectors.toMap(Users::getId, Function.identity()));
+
+            // 참여 가족 id를 통해 현재 가족 구성원에서 참여한 가족의 객체를 맵핑하고, MemoryPostFamilyMembers 객체를 빌드한다.
+            List<MemoryPostFamilyMembers> memoryPostFamilyMembers = participantFamilyMemberIds.stream()
+                    .map(id -> {
+                        Users user = familyMemberMap.get(id);
+                        if (user == null) {
+                            throw UsersErrorCode.FAMILY_MEMBER_NOT_FOUND.defaultException();
+                        }
+                        return MemoryPostFamilyMembers.builder()
+                                .joinedFamilyMember(user)
+                                .memoryPost(memoryPost)
+                                .build();
+                    })
+                    .toList();
+
+            memoryPostFamilyMembersRepository.saveAll(memoryPostFamilyMembers);
+        }
+
+        // TODO : 추후 이미지 저장 로직 여기서 추가 구현
 
         MemoryPostDto memoryPostDto = MemoryPostDto.from(memoryPost);
 
@@ -82,6 +118,28 @@ public class MemoryPostService {
             throw MemoryPostErrorCode.MEMORY_POST_NOT_FOUND.defaultException();
         }
         memoryPostRepository.delete(memoryPost);
+    }
+
+    @Transactional(readOnly = true)
+    public GetMemoryPostFamilyMembersResponse getMemoryPostFamilyMembers(Long postId) {
+        MemoryPost post = memoryPostRepository.findById(postId)
+                .orElseThrow(MemoryPostErrorCode.MEMORY_POST_NOT_FOUND::defaultException);
+
+        List<MemoryPostFamilyMembers> relations = memoryPostFamilyMembersRepository.findAllByMemoryPost(post);
+
+        List<FamilyMemberDto> participants = relations.stream()
+                .map(MemoryPostFamilyMembers::getJoinedFamilyMember)
+                .sorted(Comparator
+                        .comparing((Users u) -> {
+                            UserFamilyRole userFamilyRole = u.getUserFamilyRole();
+                            return userFamilyRole != null ? userFamilyRole.getSortOrder() : Integer.MAX_VALUE;
+                        })
+                        .thenComparing(BaseTimeEntity::getCreatedAt))
+                .map(FamilyMemberDto::from)
+                .toList();
+
+
+        return GetMemoryPostFamilyMembersResponse.from(postId, participants);
     }
 
 }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
@@ -1,0 +1,87 @@
+package com.example.dearfam.domain.memoryposts.memorypost.service;
+
+import com.example.dearfam.domain.family.entity.Family;
+import com.example.dearfam.domain.family.exception.FamilyErrorCode;
+import com.example.dearfam.domain.memoryposts.memorypost.controller.response.GetMemoryPostResponse;
+import com.example.dearfam.domain.memoryposts.memorypost.controller.response.GetUpdatedPostResponse;
+import com.example.dearfam.domain.memoryposts.memorypost.dto.MemoryPostDto;
+import com.example.dearfam.domain.memoryposts.memorypost.entity.MemoryPost;
+import com.example.dearfam.domain.memoryposts.memorypost.exception.MemoryPostErrorCode;
+import com.example.dearfam.domain.memoryposts.memorypost.repository.MemoryPostRepository;
+import com.example.dearfam.domain.users.entity.Users;
+import com.example.dearfam.domain.users.exception.UsersErrorCode;
+import com.example.dearfam.domain.users.repository.UsersRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MemoryPostService {
+    private final UsersRepository usersRepository;
+    private final MemoryPostRepository memoryPostRepository;
+
+    @Transactional
+    public GetMemoryPostResponse createMemoryPost(Long writerId, String title, String content,
+                                                  LocalDate memoryDate, List<Long> participantFamilyMemberIds) {
+
+        Users writer = usersRepository.findById(writerId)
+                .orElseThrow(UsersErrorCode.USER_NOT_FOUND::defaultException);
+
+        Family family = writer.getFamily();
+        if (family == null) {
+            throw FamilyErrorCode.FAMILY_NOT_FOUND.defaultException();
+        }
+
+        MemoryPost memoryPost = MemoryPost.builder()
+                .writer(writer)
+                .family(family)
+                .memoryPostTitle(title)
+                .memoryPostContent(content)
+                .memoryDate(memoryDate)
+                .build();
+
+        memoryPostRepository.save(memoryPost);
+
+        // TODO : 추후 참여자, 이미지 저장 로직 여기서 추가 구현
+
+        MemoryPostDto memoryPostDto = MemoryPostDto.from(memoryPost);
+
+        return GetMemoryPostResponse.from(memoryPostDto);
+    }
+
+    @Transactional
+    public GetUpdatedPostResponse updateMemoryPost(Long writerId, Long postId, String title, String content) {
+
+        MemoryPost memoryPost = memoryPostRepository.findById(postId)
+                .orElseThrow(MemoryPostErrorCode.MEMORY_POST_NOT_FOUND::defaultException);
+
+        if (!memoryPost.getWriter().getId().equals(writerId)) {
+            throw MemoryPostErrorCode.MEMORY_POST_NOT_FOUND.defaultException();
+        }
+
+        memoryPost.setMemoryPostTitle(title);
+        memoryPost.setMemoryPostContent(content);
+        memoryPostRepository.save(memoryPost);
+
+        return GetUpdatedPostResponse.from(memoryPost.getId(),
+                memoryPost.getMemoryPostTitle(),
+                memoryPost.getMemoryPostContent()
+        );
+    }
+
+    @Transactional
+    public void deleteMemoryPost(Long writerId, Long postId) {
+        MemoryPost memoryPost = memoryPostRepository.findById(postId)
+                .orElseThrow(MemoryPostErrorCode.MEMORY_POST_NOT_FOUND::defaultException);
+
+        if (!memoryPost.getWriter().getId().equals(writerId)) {
+            throw MemoryPostErrorCode.MEMORY_POST_NOT_FOUND.defaultException();
+        }
+        memoryPostRepository.delete(memoryPost);
+    }
+
+}

--- a/src/main/java/com/example/dearfam/domain/users/controller/request/UserNicknameRequest.java
+++ b/src/main/java/com/example/dearfam/domain/users/controller/request/UserNicknameRequest.java
@@ -3,10 +3,13 @@ package com.example.dearfam.domain.users.controller.request;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class UserNicknameRequest {
     @NotEmpty
     private String nickname;
 }
+

--- a/src/main/java/com/example/dearfam/domain/users/controller/response/GetUserResponse.java
+++ b/src/main/java/com/example/dearfam/domain/users/controller/response/GetUserResponse.java
@@ -14,7 +14,7 @@ import static lombok.AccessLevel.PRIVATE;
 public class GetUserResponse {
     private Long id;
     private Long familyId;
-    private String userNickName;
+    private String userNickname;
     private String userRole;
     private UserFamilyRole userFamilyRole;
     private Boolean isFamilyRoomManager;
@@ -24,7 +24,7 @@ public class GetUserResponse {
         return GetUserResponse.builder()
                 .id(usersDto.getId())
                 .familyId(usersDto.getFamily() != null ? usersDto.getFamily().getId() : null)
-                .userNickName(usersDto.getUserNickName())
+                .userNickname(usersDto.getUserNickName())
                 .userRole(usersDto.getUserRole())
                 .userFamilyRole(usersDto.getUserFamilyRole())
                 .isFamilyRoomManager(usersDto.getIsFamilyRoomManager())

--- a/src/main/java/com/example/dearfam/domain/users/dto/FamilyMemberDto.java
+++ b/src/main/java/com/example/dearfam/domain/users/dto/FamilyMemberDto.java
@@ -1,5 +1,6 @@
 package com.example.dearfam.domain.users.dto;
 
+import com.example.dearfam.domain.family.dto.FamilyDto;
 import com.example.dearfam.domain.users.entity.UserFamilyRole;
 import com.example.dearfam.domain.users.entity.Users;
 import lombok.AccessLevel;
@@ -14,25 +15,22 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 @Builder(access = AccessLevel.PRIVATE)
 public class FamilyMemberDto {
-    private Long userId;
-    private String userNickname;
-    private UserFamilyRole userFamilyRole;
+    private Long familyMemberId;
+    private String familyMemberNickname;
+    private UserFamilyRole familyMemberRole;
+    // TODO : 여기에 이미지도 같이 넣지~
 
-    public static FamilyMemberDto from(Long userId, String userNickname, UserFamilyRole userFamilyRole) {
+    public static FamilyMemberDto from(Users familyMember) {
         return FamilyMemberDto.builder()
-                .userId(userId)
-                .userNickname(userNickname)
-                .userFamilyRole(userFamilyRole)
+                .familyMemberId(familyMember.getId())
+                .familyMemberNickname(familyMember.getUserNickname())
+                .familyMemberRole(familyMember.getUserFamilyRole())
                 .build();
     }
 
-    public static List<FamilyMemberDto> from(List<Users> users) {
-        return users.stream()
-                .map(user -> FamilyMemberDto.from(
-                        user.getId(),
-                        user.getUserNickname(),
-                        user.getUserFamilyRole()
-                ))
+    public static List<FamilyMemberDto> from(List<Users> familyMembers) {
+        return familyMembers.stream()
+                .map(FamilyMemberDto::from)
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/dearfam/domain/users/entity/UserFamilyRole.java
+++ b/src/main/java/com/example/dearfam/domain/users/entity/UserFamilyRole.java
@@ -6,10 +6,16 @@ import lombok.Getter;
 @Getter
 @Schema(description = "가족 내 역할", example = "FATHER", allowableValues = {"MOTHER", "FATHER", "SON", "DAUGHTER"})
 public enum UserFamilyRole {
-    FATHER,
-    MOTHER,
-    SON,
-    DAUGHTER;
+    FATHER(0),
+    MOTHER(1),
+    SON(2),
+    DAUGHTER(2);
+
+    private final int sortOrder;
+
+    UserFamilyRole(int sortOrder) {
+        this.sortOrder = sortOrder;
+    }
 
     public boolean isParent() {
         return this == MOTHER || this == FATHER;

--- a/src/main/java/com/example/dearfam/domain/users/exception/UsersErrorCode.java
+++ b/src/main/java/com/example/dearfam/domain/users/exception/UsersErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 public enum UsersErrorCode implements ErrorCode {
     NICKNAME_ALREADY_EXISTS("이미 사용 중인 닉네임입니다.", HttpStatus.CONFLICT),
     USER_NOT_FOUND("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    FAMILY_MEMBER_NOT_FOUND("가족 구성원을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
     INVALID_USER_REQUEST("유효하지 않은 사용자 요청입니다.", HttpStatus.BAD_REQUEST),
     INVALID_ROLE("허용되지 않은 역할입니다.", HttpStatus.BAD_REQUEST),
     PROFILE_IMAGE_PROCESSING_ERROR("프로필 이미지 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/com/example/dearfam/domain/users/repository/UsersRepository.java
+++ b/src/main/java/com/example/dearfam/domain/users/repository/UsersRepository.java
@@ -15,4 +15,5 @@ public interface UsersRepository extends JpaRepository<Users, Long> {
     boolean existsByFamilyAndUserFamilyRole(Family family, UserFamilyRole userFamilyRole);
     List<Users> findAllByFamily(Family family);
     Optional<Users> findByEmail(String email);
+    List<Users> findAllByFamilyId(Long familyId);
 }

--- a/src/main/java/com/example/dearfam/domain/users/service/UsersService.java
+++ b/src/main/java/com/example/dearfam/domain/users/service/UsersService.java
@@ -4,9 +4,9 @@ import com.example.dearfam.domain.users.dto.UsersDto;
 import com.example.dearfam.domain.users.entity.Users;
 import com.example.dearfam.domain.users.exception.UsersErrorCode;
 import com.example.dearfam.domain.users.repository.UsersRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -15,7 +15,7 @@ import java.util.Optional;
 public class UsersService {
     private final UsersRepository usersRepository;
 
-    @Transactional
+    @Transactional(readOnly = true)
     public UsersDto getUserDtoById(Long id) {
         Users user = usersRepository.findById(id)
                 .orElseThrow(UsersErrorCode.USER_NOT_FOUND::defaultException);

--- a/src/test/java/com/example/dearfam/common/exception/handler/ValidationExceptionHandlerTest.java
+++ b/src/test/java/com/example/dearfam/common/exception/handler/ValidationExceptionHandlerTest.java
@@ -11,7 +11,7 @@ import org.springframework.http.ResponseEntity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-class GlobalExceptionHandlerTest {
+class ValidationExceptionHandlerTest {
 
     private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
 


### PR DESCRIPTION
### Validation 오류 처리
* GlobalExceptionhandler에 Request Dto에 잘못된 요청이 들어왔을 시 에러 처리를 구현함
    - 400 Bad Request 처리

### MemoryPost
* 게시글 생성, 수정, 조회, 삭제 기능을 구현
    - 게시글 삭제 시, 댓글과 좋아요 정보까지 모두 cascade 삭제 구현
    - 가족구성원이 작성한 게시글만 조회 가능
    - 추후 이미지 처리 예정

### MemoryPostFamilyMembers
* 게시글 생성 시, 게시글 추억에 참여한 가족들의 정보를 저장함

### MemoryPostComment
* 댓글 생성, 삭제, 조회 기능을 구현

### MemoryPostLike
* 좋아요 로직을 구현
   - 좋아요를 할 시, 좋아요한 정보가 테이블에 생성됨
   - like 컬럼은 기본 true로 설정, 좋아요를 취소하거나 다시 실행할 시에 false, true로 변경됨
   - 기존에는 좋아요 시에 테이블에 컬럼을 생성, 좋아요 취소 시 테이블 컬럼을 삭제하는 방식이었으나, 사용자 증가와 함께 좋아요가 반복될수록 테이블 컬럼을 생성하고 삭제하는 작업을 하는 것은 비효율적이고 ID 값이 너무 빠르게 증가할 것이라는 판단
   - 추후 사용자 증가 시 데이터가 누적 관리 필요 
