### PR TITLE
S3 Upload/Delete 로직 구현 & MemoryPost 생성/삭제 이미지 처리 완료

### DIFF
--- a/src/main/java/com/example/dearfam/common/exception/errorcode/S3ErrorCode.java
+++ b/src/main/java/com/example/dearfam/common/exception/errorcode/S3ErrorCode.java
@@ -11,7 +11,8 @@ public enum S3ErrorCode implements ErrorCode{
     INVALID_IMAGE_MIME("이미지 MIME 타입이 아닙니다", HttpStatus.UNSUPPORTED_MEDIA_TYPE),
     UNSUPPORTED_EXTENSION("지원하지 않는 확장자입니다", HttpStatus.BAD_REQUEST),
     MISSING_EXTENSION("확장자가 없습니다", HttpStatus.BAD_REQUEST),
-    UPLOAD_FAILED("S3 업로드에 실패했습니다", HttpStatus.INTERNAL_SERVER_ERROR);
+    UPLOAD_FAILED("S3 업로드에 실패했습니다", HttpStatus.INTERNAL_SERVER_ERROR),
+    IMAGE_LIMIT_EXCEEDED("이미지는 최대 10개까지 업로드 가능합니다", HttpStatus.BAD_REQUEST);
 
     private final String message;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/dearfam/common/exception/errorcode/S3ErrorCode.java
+++ b/src/main/java/com/example/dearfam/common/exception/errorcode/S3ErrorCode.java
@@ -11,8 +11,9 @@ public enum S3ErrorCode implements ErrorCode{
     INVALID_IMAGE_MIME("이미지 MIME 타입이 아닙니다", HttpStatus.UNSUPPORTED_MEDIA_TYPE),
     UNSUPPORTED_EXTENSION("지원하지 않는 확장자입니다", HttpStatus.BAD_REQUEST),
     MISSING_EXTENSION("확장자가 없습니다", HttpStatus.BAD_REQUEST),
+    IMAGE_LIMIT_EXCEEDED("이미지는 최대 10개까지 업로드 가능합니다", HttpStatus.BAD_REQUEST),
     UPLOAD_FAILED("S3 업로드에 실패했습니다", HttpStatus.INTERNAL_SERVER_ERROR),
-    IMAGE_LIMIT_EXCEEDED("이미지는 최대 10개까지 업로드 가능합니다", HttpStatus.BAD_REQUEST);
+    DELETE_FAILED("S3 이미지 삭제에 실패했습니다", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String message;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/dearfam/common/service/S3Service.java
+++ b/src/main/java/com/example/dearfam/common/service/S3Service.java
@@ -1,0 +1,99 @@
+package com.example.dearfam.common.service;
+
+import com.example.dearfam.common.exception.errorcode.S3ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png");
+
+    public String upload(MultipartFile file, Long postId) {
+        //1. 파일 유효성 검사하기
+        validateImageFile(file);
+
+        // 2. S3에 저장될 파일 경로 생성 (e.g., posts/1/uuid.jpg)
+        String extension = getExtension(file);
+        String key = generateKey(postId, extension);
+
+        // 3. S3 업로드 요청 객체 생성
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .contentType(file.getContentType())
+                .contentLength(file.getSize())
+                .build();
+        try {
+            s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+            log.info("파일 업로드 성공 - postId: {}, fileName: {}, key: {}", postId, file.getOriginalFilename(), key);
+        } catch (IOException e) {
+            log.error("파일을 읽어오는 중 오류가 발생했습니다.", e);
+            throw S3ErrorCode.UPLOAD_FAILED.defaultException(e);
+        } catch (SdkException e) {
+            log.error("S3 업로드에 실패했습니다.", e);
+            throw S3ErrorCode.UPLOAD_FAILED.defaultException(e);
+        }
+
+        return key;
+    }
+
+    public String generateUrlFromKey(String key) {
+        GetUrlRequest getUrlRequest = GetUrlRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+        return s3Client.utilities().getUrl(getUrlRequest).toExternalForm();
+    }
+
+    private void validateImageFile(MultipartFile file) {
+        // 파일이 비어있을 때
+        if (file.isEmpty()) {
+            throw S3ErrorCode.EMPTY_FILE.defaultException();
+        }
+        // TODO: 파일이 image 검사 X multipart/form-data 인지를 검사
+        // 파일이 이미지가 아닐때 (Content Type이 image로 시작하지 않는 경우)
+//        if (!Objects.requireNonNull(file.getContentType()).startsWith("image/")) {
+//            log.error(file.getContentType());
+//            throw S3ErrorCode.INVALID_IMAGE_MIME.defaultException();
+//        }
+        // 지원하지 않는 확장자인 경우
+        if (!ALLOWED_EXTENSIONS.contains(getExtension(file))) {
+            throw S3ErrorCode.UNSUPPORTED_EXTENSION.defaultException();
+        }
+    }
+
+    // 파일 확장자 추출하는 함수
+    private String getExtension(MultipartFile file) {
+        String fileName = file.getOriginalFilename();
+        if (fileName == null || !Objects.requireNonNull(fileName).contains(".")) {
+            throw S3ErrorCode.MISSING_EXTENSION.defaultException();
+        }
+        return fileName.substring(fileName.lastIndexOf(".") + 1).toLowerCase();
+    }
+
+    private String generateKey(Long postId, String extension) {
+        return "posts/" + postId + "/" + UUID.randomUUID() + "." + extension;
+    }
+
+}

--- a/src/main/java/com/example/dearfam/common/service/S3Service.java
+++ b/src/main/java/com/example/dearfam/common/service/S3Service.java
@@ -9,6 +9,7 @@ import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetUrlRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
@@ -56,6 +57,20 @@ public class S3Service {
         }
 
         return key;
+    }
+
+    public void delete(String key) {
+        try {
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build();
+            s3Client.deleteObject(deleteObjectRequest);
+            log.info("S3 이미지 삭제 성공 - key: {}", key);
+        } catch (SdkException e) {
+            log.error("S3 이미지 삭제 실패 - key: {}", key, e);
+            throw S3ErrorCode.DELETE_FAILED.defaultException(e);
+        }
     }
 
     public String generateUrlFromKey(String key) {

--- a/src/main/java/com/example/dearfam/common/service/S3Service.java
+++ b/src/main/java/com/example/dearfam/common/service/S3Service.java
@@ -30,7 +30,7 @@ public class S3Service {
 
     private static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png");
 
-    public String upload(MultipartFile file, Long postId) {
+    public String uploadPostImages(MultipartFile file, Long postId) {
         //1. 파일 유효성 검사하기
         validateImageFile(file);
 

--- a/src/main/java/com/example/dearfam/domain/memoryposts/image/dto/MemoryPostImageDto.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/image/dto/MemoryPostImageDto.java
@@ -1,0 +1,23 @@
+package com.example.dearfam.domain.memoryposts.image.dto;
+
+import com.example.dearfam.domain.memoryposts.image.entity.MemoryPostImage;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class MemoryPostImageDto {
+
+    private final String imageUrl;
+    private final int imageOrder;
+
+    public static MemoryPostImageDto from(MemoryPostImage memoryPostImage, String imageUrl) {
+        return MemoryPostImageDto.builder()
+                .imageUrl(imageUrl)
+                .imageOrder(memoryPostImage.getImageOrder())
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/image/entity/MemoryPostImage.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/image/entity/MemoryPostImage.java
@@ -1,0 +1,37 @@
+package com.example.dearfam.domain.memoryposts.image.entity;
+
+import com.example.dearfam.common.entity.BaseTimeEntity;
+import com.example.dearfam.domain.memoryposts.memorypost.entity.MemoryPost;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "memory_post_image")
+public class MemoryPostImage extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "memory_post_image_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "memory_post_id", nullable = false)
+    private MemoryPost memoryPost;
+
+    @Column(name = "memory_post_image_key", nullable = false)
+    private String imageKey;
+
+    @Column(name = "image_order", nullable = false)
+    private Integer imageOrder;
+
+    @Builder
+    public MemoryPostImage(String imageKey, Integer imageOrder) {
+        this.imageKey = imageKey;
+        this.imageOrder = imageOrder;
+    }
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/image/repository/MemoryPostImageRepository.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/image/repository/MemoryPostImageRepository.java
@@ -1,0 +1,9 @@
+package com.example.dearfam.domain.memoryposts.image.repository;
+
+import com.example.dearfam.domain.memoryposts.image.entity.MemoryPostImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemoryPostImageRepository extends JpaRepository<MemoryPostImage, Long> {
+}

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/MemoryPostController.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/MemoryPostController.java
@@ -1,6 +1,7 @@
 package com.example.dearfam.domain.memoryposts.memorypost.controller;
 
 import com.example.dearfam.common.dto.response.Response;
+import com.example.dearfam.common.exception.errorcode.S3ErrorCode;
 import com.example.dearfam.common.jwt.auth.JwtService;
 import com.example.dearfam.domain.memoryposts.memorypost.controller.request.CreateMemoryPostRequest;
 import com.example.dearfam.domain.memoryposts.memorypost.controller.request.UpdateMemoryPostRequest;
@@ -11,11 +12,15 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.util.List;
 
+@Slf4j
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/memory-post")
@@ -33,21 +38,24 @@ public class MemoryPostController {
                     @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
             }
     )
-    @PostMapping
-    public Response<GetMemoryPostResponse> createMemoryPost(@Valid @RequestBody CreateMemoryPostRequest createMemoryPostRequest) {
+    @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public Response<GetMemoryPostResponse> createMemoryPost(
+            @Valid @RequestPart("request") CreateMemoryPostRequest createMemoryPostRequest,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images) {
+
+        // 이미지 개수 제한
+        if (images != null && images.size() > 10) {
+            log.error("이미지는 최대 10개까지 업로드 가능합니다.");
+            throw S3ErrorCode.IMAGE_LIMIT_EXCEEDED.defaultException();
+        }
+
         // 로그인한 유저가 게시글을 올리면, writer 는 현재 로그인한 유저임.
         Long writerId = jwtService.getTokenDto().getUserId();
-        String title = createMemoryPostRequest.getTitle();
-        String content = createMemoryPostRequest.getContent();
-        LocalDate memoryDate = createMemoryPostRequest.getMemoryDate();
-        List<Long> participantFamilyMemberIds = createMemoryPostRequest.getParticipantFamilyMemberIds();
 
         GetMemoryPostResponse response = memoryPostService.createMemoryPost(
                 writerId,
-                title,
-                content,
-                memoryDate,
-                participantFamilyMemberIds
+                createMemoryPostRequest,
+                images
                 );
 
         return Response.data(response);

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/response/GetMemoryPostResponse.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/response/GetMemoryPostResponse.java
@@ -1,5 +1,6 @@
 package com.example.dearfam.domain.memoryposts.memorypost.controller.response;
 
+import com.example.dearfam.domain.memoryposts.image.dto.MemoryPostImageDto;
 import com.example.dearfam.domain.memoryposts.members.dto.MemoryPostFamilyMembersDto;
 import com.example.dearfam.domain.memoryposts.memorypost.dto.MemoryPostDto;
 import lombok.AllArgsConstructor;
@@ -7,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -24,12 +26,17 @@ public class GetMemoryPostResponse {
     private LocalDate memoryDate;
     private boolean isLiked;
     private List<MemoryPostFamilyMembersDto> participantFamilyMembers;
-
-    // TODO : 추후 이미지는 id로 보낼지, 이미지 파일로 보낼지 한 번 고민
+    private List<MemoryPostImageDto> imageUrls;
 
     public static GetMemoryPostResponse from(MemoryPostDto memoryPostDto,
                                              List<MemoryPostFamilyMembersDto> participantFamilyMembers,
+                                             List<MemoryPostImageDto> images,
                                              boolean isLiked) {
+        // image를 순서대로 배치
+        List<MemoryPostImageDto> sortedImages = images.stream()
+                .sorted(Comparator.comparingInt(MemoryPostImageDto::getImageOrder))
+                .toList();
+
         return GetMemoryPostResponse.builder()
                 .writerId(memoryPostDto.getWriter().getId())
                 .title(memoryPostDto.getMemoryPostTitle())
@@ -37,6 +44,7 @@ public class GetMemoryPostResponse {
                 .memoryDate(memoryPostDto.getMemoryDate())
                 .isLiked(isLiked)
                 .participantFamilyMembers(participantFamilyMembers)
+                .imageUrls(sortedImages)
                 .build();
     }
 

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/dto/MemoryPostDto.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/dto/MemoryPostDto.java
@@ -1,6 +1,7 @@
 package com.example.dearfam.domain.memoryposts.memorypost.dto;
 
 import com.example.dearfam.domain.family.entity.Family;
+import com.example.dearfam.domain.memoryposts.image.dto.MemoryPostImageDto;
 import com.example.dearfam.domain.memoryposts.memorypost.entity.MemoryPost;
 import com.example.dearfam.domain.users.entity.Users;
 import lombok.AllArgsConstructor;
@@ -9,6 +10,7 @@ import lombok.Getter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/entity/MemoryPost.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/entity/MemoryPost.java
@@ -3,6 +3,7 @@ package com.example.dearfam.domain.memoryposts.memorypost.entity;
 import com.example.dearfam.common.entity.BaseTimeEntity;
 import com.example.dearfam.domain.family.entity.Family;
 import com.example.dearfam.domain.memoryposts.comment.entity.MemoryPostComment;
+import com.example.dearfam.domain.memoryposts.image.entity.MemoryPostImage;
 import com.example.dearfam.domain.memoryposts.like.entity.MemoryPostLike;
 import com.example.dearfam.domain.memoryposts.members.entity.MemoryPostFamilyMembers;
 import com.example.dearfam.domain.users.entity.Users;
@@ -51,7 +52,8 @@ public class MemoryPost extends BaseTimeEntity {
     @Column(name = "memory_date", nullable = false)
     private LocalDate memoryDate;
 
-    // TODO : 이미지 엔티티 만들고, OneToMany 로 추가하기
+    @OneToMany(mappedBy = "memoryPost", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MemoryPostImage> memoryPostImages = new ArrayList<>();
 
     @OneToMany(mappedBy = "memoryPost", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemoryPostComment> memoryPostComments = new ArrayList<>();
@@ -72,6 +74,12 @@ public class MemoryPost extends BaseTimeEntity {
         this.memoryPostCommentCount = memoryPostCommentCount == null ? 0 : memoryPostCommentCount;
         this.memoryPostImageCount = memoryPostImageCount == null ? 0 : memoryPostImageCount;
         this.memoryDate = memoryDate;
+    }
+
+    // 양방향 관계 설정
+    public void addImage(MemoryPostImage image) {
+        this.memoryPostImages.add(image);
+        image.setMemoryPost(this);
     }
 
 }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
@@ -78,7 +78,7 @@ public class MemoryPostService {
         if (images != null && !images.isEmpty()) {
             log.info("이미지 null 값 아님");
             for (int i = 0; i < images.size(); i++) {
-                String imageKey = s3Service.upload(images.get(i), memoryPost.getId());
+                String imageKey = s3Service.uploadPostImages(images.get(i), memoryPost.getId());
                 String imageUrl = s3Service.generateUrlFromKey(imageKey);
                 MemoryPostImage image = MemoryPostImage.builder()
                         .imageKey(imageKey)

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
@@ -155,7 +155,20 @@ public class MemoryPostService {
         if (!memoryPost.getWriter().getId().equals(writerId)) {
             throw MemoryPostErrorCode.UNAUTHORIZED_MEMORY_POST_ACCESS.defaultException();
         }
+
+        List<MemoryPostImage> images = memoryPost.getMemoryPostImages();
+        for (MemoryPostImage img: images) {
+            String key = img.getImageKey();
+            if (key != null) {
+                log.info("이미지 삭제 요청");
+                s3Service.delete(key);
+            } else {
+                log.warn("이미지의 key 값이 null입니다. postId={}, imageId={}", memoryPost.getId(), img.getId());
+            }
+        }
+
         memoryPostRepository.delete(memoryPost);
+        log.info("게시글 삭제 완료");
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
@@ -1,13 +1,17 @@
 package com.example.dearfam.domain.memoryposts.memorypost.service;
 
 import com.example.dearfam.common.entity.BaseTimeEntity;
-import com.example.dearfam.common.jwt.auth.JwtService;
+import com.example.dearfam.common.service.S3Service;
 import com.example.dearfam.domain.family.entity.Family;
 import com.example.dearfam.domain.family.exception.FamilyErrorCode;
+import com.example.dearfam.domain.memoryposts.image.dto.MemoryPostImageDto;
+import com.example.dearfam.domain.memoryposts.image.entity.MemoryPostImage;
+import com.example.dearfam.domain.memoryposts.image.repository.MemoryPostImageRepository;
 import com.example.dearfam.domain.memoryposts.like.repository.MemoryPostLikeRepository;
 import com.example.dearfam.domain.memoryposts.members.dto.MemoryPostFamilyMembersDto;
 import com.example.dearfam.domain.memoryposts.members.entity.MemoryPostFamilyMembers;
 import com.example.dearfam.domain.memoryposts.members.repository.MemoryPostFamilyMembersRepository;
+import com.example.dearfam.domain.memoryposts.memorypost.controller.request.CreateMemoryPostRequest;
 import com.example.dearfam.domain.memoryposts.memorypost.controller.response.*;
 import com.example.dearfam.domain.memoryposts.memorypost.dto.MemoryPostDto;
 import com.example.dearfam.domain.memoryposts.memorypost.dto.SimpleMemoryPostDto;
@@ -20,14 +24,17 @@ import com.example.dearfam.domain.users.entity.Users;
 import com.example.dearfam.domain.users.exception.UsersErrorCode;
 import com.example.dearfam.domain.users.repository.UsersRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MemoryPostService {
@@ -35,10 +42,16 @@ public class MemoryPostService {
     private final MemoryPostRepository memoryPostRepository;
     private final MemoryPostFamilyMembersRepository memoryPostFamilyMembersRepository;
     private final MemoryPostLikeRepository memoryPostLikeRepository;
+    private final S3Service s3Service;
+    private final MemoryPostImageRepository memoryPostImageRepository;
 
     @Transactional
-    public GetMemoryPostResponse createMemoryPost(Long writerId, String title, String content,
-                                                  LocalDate memoryDate, List<Long> participantFamilyMemberIds) {
+    public GetMemoryPostResponse createMemoryPost(Long writerId, CreateMemoryPostRequest requestDto, List<MultipartFile> images) {
+
+        String title = requestDto.getTitle();
+        String content = requestDto.getContent();
+        LocalDate memoryDate = requestDto.getMemoryDate();
+        List<Long> participantFamilyMemberIds = requestDto.getParticipantFamilyMemberIds();
 
         Users writer = usersRepository.findById(writerId)
                 .orElseThrow(UsersErrorCode.USER_NOT_FOUND::defaultException);
@@ -48,8 +61,6 @@ public class MemoryPostService {
             throw FamilyErrorCode.FAMILY_NOT_FOUND.defaultException();
         }
 
-        // TODO : 추후 이미지 저장 로직 여기서 추가 구현 후 memoryPostRepository save 하는 순서가 맞음.
-
         MemoryPost memoryPost = MemoryPost.builder()
                 .writer(writer)
                 .family(family)
@@ -57,12 +68,33 @@ public class MemoryPostService {
                 .memoryPostContent(content)
                 .memoryDate(memoryDate)
                 .build();
-
         // 생성한 게시글 저장
         memoryPostRepository.save(memoryPost);
+        log.info("게시글 생성 완료");
 
+
+        List<MemoryPostImageDto> imageDtos = new ArrayList<>();
+        // 이미지 S3에 저장 후 DB에 URL 과 순서 저장
+        if (images != null && !images.isEmpty()) {
+            log.info("이미지 null 값 아님");
+            for (int i = 0; i < images.size(); i++) {
+                String imageKey = s3Service.upload(images.get(i), memoryPost.getId());
+                String imageUrl = s3Service.generateUrlFromKey(imageKey);
+                MemoryPostImage image = MemoryPostImage.builder()
+                        .imageKey(imageKey)
+                        .imageOrder(i + 1)
+                        .build();
+
+                memoryPost.addImage(image); // 연관관계 양방향 설정
+                imageDtos.add(MemoryPostImageDto.from(image, imageUrl));
+            }
+            memoryPost.setMemoryPostImageCount(memoryPost.getMemoryPostImages().size());
+            memoryPostRepository.save(memoryPost); // Cascade 설정돼 있으면 이미지도 저장됨
+            log.info("이미지 저장 완료");
+        }
+
+        // 게시글에 참여한 가족 구성원 저장
         List<MemoryPostFamilyMembers> memoryPostFamilyMembers = List.of();
-
         if (participantFamilyMemberIds != null && !participantFamilyMemberIds.isEmpty()) {
             // 현재 가족 구성원 조회
             List<Users> familyMembers = usersRepository.findAllByFamilyId(family.getId());
@@ -85,18 +117,14 @@ public class MemoryPostService {
                                 .build();
                     })
                     .toList();
-
-            // 게시글에 참여한 가족 구성원 저장
             memoryPostFamilyMembersRepository.saveAll(memoryPostFamilyMembers);
         }
 
         MemoryPostDto memoryPostDto = MemoryPostDto.from(memoryPost);
-
         List<MemoryPostFamilyMembersDto> membersDtos = MemoryPostFamilyMembersDto.from(memoryPostFamilyMembers);
-
         boolean isLiked = memoryPostLikeRepository.existsByLikedUserAndMemoryPost(writer, memoryPost);
 
-        return GetMemoryPostResponse.from(memoryPostDto, membersDtos, isLiked);
+        return GetMemoryPostResponse.from(memoryPostDto, membersDtos, imageDtos, isLiked);
     }
 
     @Transactional
@@ -171,9 +199,13 @@ public class MemoryPostService {
             throw MemoryPostErrorCode.UNAUTHORIZED_FAMILY_ACCESS.defaultException();
         }
 
+        List<MemoryPostImageDto> imageDtos = memoryPost.getMemoryPostImages().stream()
+                .map(img -> MemoryPostImageDto.from(img, s3Service.generateUrlFromKey(img.getImageKey())))
+                .toList();
+
         boolean isLiked = memoryPostLikeRepository.existsByLikedUserAndMemoryPost(user, memoryPost);
 
-        return GetMemoryPostResponse.from(memoryPostDto, participants, isLiked);
+        return GetMemoryPostResponse.from(memoryPostDto, participants, imageDtos, isLiked);
     }
 
 


### PR DESCRIPTION
### S3 Upload/Delete 로직
    - S3 Upload
         - MemoryPostController에서 file 의 size 가 10 초과인지 확인 (최대 10개) 
         - S3Service 클래스에서 uploadPostImages 메서드를 통해 S3에 사진을 업로드하는 로직을 구현함.
             - 업로드 시 파일의 유효성 검사 : validate
             - 이미지의 Key 생성을 하기 위한 extension 추출 메서드 : getExtension
    - S3 Delete
         - delete 함수를 통해 post 에 연결된 S3 이미지들을 삭제
    - Client 에 반환 시 url 로 반환 : generateUrlFromKey

### MemoryPost 생성/삭제
    - MemoryPost 생성
        - 이미지 S3에 저장 후 DB에 URL 과 순서 저장
        - GetMemoryPostResponse Dto 반환 시 순서대로 정렬 후 반환
    - MemoryPost 삭제
        - 기존 deleteMemoryPost 함수에, S3 이미지 삭제 로직 추가