### PR TITLE
S3 이미지 업로드 시 분류 로직 생성 & GET API를 통한 조회 시 이미지 반환 로직 구현 완료

### DIFF
--- a/src/main/java/com/example/dearfam/common/dto/response/Response.java
+++ b/src/main/java/com/example/dearfam/common/dto/response/Response.java
@@ -17,4 +17,8 @@ public class Response<T> {
     public static <T> Response<T> data(T data) {
         return new Response<>(0, "", data);
     }
+
+    public static <T> Response<T> data(String message, T data) {
+        return new Response<>(0, message, data);
+    }
 }

--- a/src/main/java/com/example/dearfam/common/entity/UploadDirectory.java
+++ b/src/main/java/com/example/dearfam/common/entity/UploadDirectory.java
@@ -1,0 +1,16 @@
+package com.example.dearfam.common.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum UploadDirectory {
+    POSTS("posts"),
+    PROFILES("profiles");
+
+    private final String baseDir;
+
+    UploadDirectory(String baseDir) {
+        this.baseDir = baseDir;
+    }
+
+}

--- a/src/main/java/com/example/dearfam/common/service/S3Service.java
+++ b/src/main/java/com/example/dearfam/common/service/S3Service.java
@@ -1,5 +1,6 @@
 package com.example.dearfam.common.service;
 
+import com.example.dearfam.common.entity.UploadDirectory;
 import com.example.dearfam.common.exception.errorcode.S3ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,11 +32,13 @@ public class S3Service {
 
     private static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png");
 
+    public String upload(MultipartFile file, UploadDirectory directory, Long id) {
         //1. 파일 유효성 검사하기
         validateImageFile(file);
 
         // 2. S3에 저장될 파일 경로 생성 (e.g., posts/1/uuid.jpg)
         String extension = getExtension(file);
+        String key = generateKey(directory, id, extension);
 
         // 3. S3 업로드 요청 객체 생성
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
@@ -46,6 +49,7 @@ public class S3Service {
                 .build();
         try {
             s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+            log.info("파일 업로드 성공 - dir: {}, id: {}, key: {}", directory, id, key);
         } catch (IOException e) {
             log.error("파일을 읽어오는 중 오류가 발생했습니다.", e);
             throw S3ErrorCode.UPLOAD_FAILED.defaultException(e);
@@ -121,6 +125,8 @@ public class S3Service {
         return fileName.substring(fileName.lastIndexOf(".") + 1).toLowerCase();
     }
 
+    private String generateKey(UploadDirectory directory, Long id, String extension) {
+        return directory.getBaseDir() + "/" + id + "/" + UUID.randomUUID() + "." + extension;
     }
 
 }

--- a/src/main/java/com/example/dearfam/common/service/S3Service.java
+++ b/src/main/java/com/example/dearfam/common/service/S3Service.java
@@ -15,6 +15,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -30,13 +31,11 @@ public class S3Service {
 
     private static final Set<String> ALLOWED_EXTENSIONS = Set.of("jpg", "jpeg", "png");
 
-    public String uploadPostImages(MultipartFile file, Long postId) {
         //1. 파일 유효성 검사하기
         validateImageFile(file);
 
         // 2. S3에 저장될 파일 경로 생성 (e.g., posts/1/uuid.jpg)
         String extension = getExtension(file);
-        String key = generateKey(postId, extension);
 
         // 3. S3 업로드 요청 객체 생성
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
@@ -47,7 +46,6 @@ public class S3Service {
                 .build();
         try {
             s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
-            log.info("파일 업로드 성공 - postId: {}, fileName: {}, key: {}", postId, file.getOriginalFilename(), key);
         } catch (IOException e) {
             log.error("파일을 읽어오는 중 오류가 발생했습니다.", e);
             throw S3ErrorCode.UPLOAD_FAILED.defaultException(e);
@@ -81,6 +79,22 @@ public class S3Service {
         return s3Client.utilities().getUrl(getUrlRequest).toExternalForm();
     }
 
+    // key 값 추출 함수
+    public Optional<String> extractKeyFromUrl(String url) {
+        if (url == null) {
+            log.info("url 값이 null 입니다.");
+            return Optional.empty();
+        }
+
+        String s3UrlPrefix = "https://" + bucket + ".s3.ap-northeast-2.amazonaws.com/";
+
+        if (!url.startsWith(s3UrlPrefix)) {
+            log.warn("s3 url 형식이 아닙니다.");
+            return Optional.empty();
+        }
+        return Optional.of(url.substring(s3UrlPrefix.length()));
+    }
+
     private void validateImageFile(MultipartFile file) {
         // 파일이 비어있을 때
         if (file.isEmpty()) {
@@ -107,8 +121,6 @@ public class S3Service {
         return fileName.substring(fileName.lastIndexOf(".") + 1).toLowerCase();
     }
 
-    private String generateKey(Long postId, String extension) {
-        return "posts/" + postId + "/" + UUID.randomUUID() + "." + extension;
     }
 
 }

--- a/src/main/java/com/example/dearfam/domain/family/service/FamilyService.java
+++ b/src/main/java/com/example/dearfam/domain/family/service/FamilyService.java
@@ -10,6 +10,7 @@ import com.example.dearfam.domain.users.dto.FamilyMemberDto;
 import com.example.dearfam.domain.users.entity.UserFamilyRole;
 import com.example.dearfam.domain.users.entity.Users;
 import com.example.dearfam.domain.users.exception.UsersErrorCode;
+import com.example.dearfam.domain.users.mapper.UsersMapper;
 import com.example.dearfam.domain.users.repository.UsersRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,6 +24,7 @@ import java.util.List;
 public class FamilyService {
     private final FamilyRepository familyRepository;
     private final UsersRepository usersRepository;
+    private final UsersMapper usersMapper;
 
     @Transactional
     public FamilyDto createFamily(String familyName, Long userId) {
@@ -145,7 +147,7 @@ public class FamilyService {
                             return userFamilyRole != null ? userFamilyRole.getSortOrder() : Integer.MAX_VALUE;
                         })
                         .thenComparing(BaseTimeEntity::getCreatedAt))
-                .map(FamilyMemberDto::from)
+                .map(usersMapper::toFamilyMemberDto)
                 .toList();
     }
 

--- a/src/main/java/com/example/dearfam/domain/memoryposts/members/dto/MemoryPostFamilyMembersDto.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/members/dto/MemoryPostFamilyMembersDto.java
@@ -18,7 +18,7 @@ public class MemoryPostFamilyMembersDto {
 
     private Long familyMemberId;
     private String nickname;
-    // TODO : 참여한 가족의 프로필 이미지를 건네줘야함
+    private String profileImage;
 
     public static MemoryPostFamilyMembersDto from(MemoryPostFamilyMembers memoryPostFamilyMembers) {
         return MemoryPostFamilyMembersDto.builder()

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/response/GetRecentMemoryPostResponse.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/controller/response/GetRecentMemoryPostResponse.java
@@ -18,18 +18,18 @@ import static lombok.AccessLevel.PRIVATE;
 @Builder(access = PRIVATE)
 public class GetRecentMemoryPostResponse {
     // 응답으로 넘겨야 하는 정보 : 게시글의 첫 번째 이미지, 제목, 내용, 게시글 참여 가족 구성원 리스트, 좋아요 여부, 댓글 수
-    // TODO : 이미지 처리 해야함.
-
     private Long postId;
     private String title;
     private String content;
     private Integer commentCount;
     private LocalDate memoryDate;
+    private String thumbnailUrl;
     private boolean isLiked;
     private List<MemoryPostFamilyMembersDto> participants;
 
     public static GetRecentMemoryPostResponse from(MemoryPostDto memoryPostDto,
                                                    List<MemoryPostFamilyMembersDto> participants,
+                                                   String thumbnailUrl,
                                                    boolean isLiked) {
         return GetRecentMemoryPostResponse.builder()
                 .postId(memoryPostDto.getId())
@@ -37,19 +37,22 @@ public class GetRecentMemoryPostResponse {
                 .content(memoryPostDto.getMemoryPostContent())
                 .commentCount(memoryPostDto.getMemoryPostCommentCount())
                 .memoryDate(memoryPostDto.getMemoryDate())
+                .thumbnailUrl(thumbnailUrl)
                 .isLiked(isLiked)
                 .participants(participants)
                 .build();
     }
 
     public static List<GetRecentMemoryPostResponse> from(List<MemoryPostDto> memoryPostDtoList,
-                                                         Map<Long, List<MemoryPostFamilyMembersDto>> participantsList,
-                                                         Map<Long, Boolean> isLikedList) {
+                                                         Map<Long, List<MemoryPostFamilyMembersDto>> participantsMap,
+                                                         Map<Long, String> thumbnailUrlMap,
+                                                         Map<Long, Boolean> isLikedMap) {
         return memoryPostDtoList.stream()
                 .map(postDto -> GetRecentMemoryPostResponse.from(
                         postDto,
-                        participantsList.getOrDefault(postDto.getId(), List.of()),
-                        isLikedList.get(postDto.getId())
+                        participantsMap.getOrDefault(postDto.getId(), List.of()),
+                        thumbnailUrlMap.get(postDto.getId()),
+                        isLikedMap.get(postDto.getId())
                 ))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/dto/SimpleMemoryPostDto.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/dto/SimpleMemoryPostDto.java
@@ -1,5 +1,6 @@
 package com.example.dearfam.domain.memoryposts.memorypost.dto;
 
+import com.example.dearfam.domain.memoryposts.image.entity.MemoryPostImage;
 import com.example.dearfam.domain.memoryposts.memorypost.entity.MemoryPost;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,18 +16,13 @@ import java.util.stream.Collectors;
 public class SimpleMemoryPostDto {
     private Long postId;
     private LocalDate memoryDate;
-//    private String imageUrl;
+    private String thumbnailUrl;
 
-    public static SimpleMemoryPostDto from(MemoryPost memoryPost) {
+    public static SimpleMemoryPostDto from(MemoryPost memoryPost, String thumbnailUrl) {
         return SimpleMemoryPostDto.builder()
                 .postId(memoryPost.getId())
                 .memoryDate(memoryPost.getMemoryDate())
+                .thumbnailUrl(thumbnailUrl)
                 .build();
-    }
-
-    public static List<SimpleMemoryPostDto> from(List<MemoryPost> memoryPosts) {
-        return memoryPosts.stream().
-                map(SimpleMemoryPostDto::from)
-                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/repository/MemoryPostRepository.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/repository/MemoryPostRepository.java
@@ -9,6 +9,6 @@ import java.util.List;
 
 @Repository
 public interface MemoryPostRepository extends JpaRepository<MemoryPost, Long> {
-    List<MemoryPost> findAllByFamilyOrderByMemoryDateDesc(Family family);
-    List<MemoryPost> findTop10ByFamilyOrderByMemoryDateDesc(Family family);
+    List<MemoryPost> findAllByFamilyOrderByMemoryDateDescCreatedAtDesc(Family family);
+    List<MemoryPost> findTop10ByFamilyOrderByMemoryDateDescCreatedAtDesc(Family family);
 }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
@@ -1,6 +1,7 @@
 package com.example.dearfam.domain.memoryposts.memorypost.service;
 
 import com.example.dearfam.common.entity.BaseTimeEntity;
+import com.example.dearfam.common.entity.UploadDirectory;
 import com.example.dearfam.common.service.S3Service;
 import com.example.dearfam.domain.family.entity.Family;
 import com.example.dearfam.domain.family.exception.FamilyErrorCode;
@@ -76,9 +77,13 @@ public class MemoryPostService {
         List<MemoryPostImageDto> imageDtos = new ArrayList<>();
         // 이미지 S3에 저장 후 DB에 URL 과 순서 저장
         if (images != null && !images.isEmpty()) {
+        boolean hasValidImages = images != null &&
+                images.stream().anyMatch(file -> file != null && !file.isEmpty());
+        if (hasValidImages) {
             log.info("이미지 null 값 아님");
             for (int i = 0; i < images.size(); i++) {
                 String imageKey = s3Service.uploadPostImages(images.get(i), memoryPost.getId());
+                String imageKey = s3Service.upload(images.get(i), UploadDirectory.POSTS,memoryPost.getId());
                 String imageUrl = s3Service.generateUrlFromKey(imageKey);
                 MemoryPostImage image = MemoryPostImage.builder()
                         .imageKey(imageKey)

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
@@ -239,6 +239,19 @@ public class MemoryPostService {
 
         List<MemoryPost> memoryPosts = memoryPostRepository.findAllByFamilyOrderByMemoryDateDesc(family);
         List<SimpleMemoryPostDto> posts = SimpleMemoryPostDto.from(memoryPosts);
+        List<SimpleMemoryPostDto> posts = memoryPosts.stream()
+                .map(post -> {
+                    String imageKey = post.getMemoryPostImages().stream()
+                            .filter(img -> img.getImageOrder() == 1)
+                            .map(MemoryPostImage::getImageKey)
+                            .findFirst()
+                            .orElse(null);
+
+                    String imageUrl = imageKey != null ? s3Service.generateUrlFromKey(imageKey) : null;
+
+                    return SimpleMemoryPostDto.from(post, imageUrl);
+                })
+                .toList();
 
         Map<Integer, List<SimpleMemoryPostDto>> postsGroupedByYear = new TreeMap<>(Comparator.reverseOrder());
 

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
@@ -78,13 +78,11 @@ public class MemoryPostService {
 
         List<MemoryPostImageDto> imageDtos = new ArrayList<>();
         // 이미지 S3에 저장 후 DB에 URL 과 순서 저장
-        if (images != null && !images.isEmpty()) {
         boolean hasValidImages = images != null &&
                 images.stream().anyMatch(file -> file != null && !file.isEmpty());
         if (hasValidImages) {
             log.info("이미지 null 값 아님");
             for (int i = 0; i < images.size(); i++) {
-                String imageKey = s3Service.uploadPostImages(images.get(i), memoryPost.getId());
                 String imageKey = s3Service.upload(images.get(i), UploadDirectory.POSTS,memoryPost.getId());
                 String imageUrl = s3Service.generateUrlFromKey(imageKey);
                 MemoryPostImage image = MemoryPostImage.builder()
@@ -128,7 +126,6 @@ public class MemoryPostService {
         }
 
         MemoryPostDto memoryPostDto = MemoryPostDto.from(memoryPost);
-        List<MemoryPostFamilyMembersDto> membersDtos = MemoryPostFamilyMembersDto.from(memoryPostFamilyMembers);
         List<MemoryPostFamilyMembersDto> membersDtos = memoryPostFamilyMembers.stream()
                 .map(usersMapper::toMemoryPostFamilyMembersDto)
                 .toList();
@@ -197,7 +194,6 @@ public class MemoryPostService {
                             return userFamilyRole != null ? userFamilyRole.getSortOrder() : Integer.MAX_VALUE;
                         })
                         .thenComparing(BaseTimeEntity::getCreatedAt))
-                .map(FamilyMemberDto::from)
                 .map(usersMapper::toFamilyMemberDto)
                 .toList();
 
@@ -214,7 +210,6 @@ public class MemoryPostService {
         MemoryPostDto memoryPostDto = MemoryPostDto.from(memoryPost);
 
         List<MemoryPostFamilyMembers> familyMembers = memoryPostFamilyMembersRepository.findAllByMemoryPost(memoryPost);
-        List<MemoryPostFamilyMembersDto> participants = MemoryPostFamilyMembersDto.from(familyMembers);
         List<MemoryPostFamilyMembersDto> participants = familyMembers.stream()
                 .map(usersMapper::toMemoryPostFamilyMembersDto)
                 .toList();
@@ -247,8 +242,7 @@ public class MemoryPostService {
             throw FamilyErrorCode.FAMILY_NOT_FOUND.defaultException();
         }
 
-        List<MemoryPost> memoryPosts = memoryPostRepository.findAllByFamilyOrderByMemoryDateDesc(family);
-        List<SimpleMemoryPostDto> posts = SimpleMemoryPostDto.from(memoryPosts);
+        List<MemoryPost> memoryPosts = memoryPostRepository.findAllByFamilyOrderByMemoryDateDescCreatedAtDesc(family);
         List<SimpleMemoryPostDto> posts = memoryPosts.stream()
                 .map(post -> {
                     String imageKey = post.getMemoryPostImages().stream()
@@ -286,11 +280,9 @@ public class MemoryPostService {
         }
 
         // memoryDate 기준 최근 10개의 데이터를 가져옴
-        List<MemoryPost> memoryPosts  = memoryPostRepository.findTop10ByFamilyOrderByMemoryDateDesc(family);
+        List<MemoryPost> memoryPosts  = memoryPostRepository.findTop10ByFamilyOrderByMemoryDateDescCreatedAtDesc(family);
         List<MemoryPostDto> memoryPostDtoList = MemoryPostDto.from(memoryPosts);
 
-        Map<Long, List<MemoryPostFamilyMembersDto>> participantsList = new HashMap<>();
-        Map<Long, Boolean> isLikedList = new HashMap<>();
         Map<Long, List<MemoryPostFamilyMembersDto>> participantsMap = new HashMap<>();
         Map<Long, Boolean> isLikedMap = new HashMap<>();
         Map<Long, String> thumbnailUrlMap = new HashMap<>();
@@ -298,8 +290,6 @@ public class MemoryPostService {
         for (MemoryPost memoryPost : memoryPosts) {
             // 참여 가족 구성원 맵핑
             List<MemoryPostFamilyMembers> members = memoryPostFamilyMembersRepository.findAllByMemoryPost(memoryPost);
-            List<MemoryPostFamilyMembersDto> memberDtoList = MemoryPostFamilyMembersDto.from(members);
-            participantsList.put(memoryPost.getId(), memberDtoList);
             List<MemoryPostFamilyMembersDto> memberDtoList = members.stream()
                     .map(usersMapper::toMemoryPostFamilyMembersDto)
                     .toList();

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
@@ -129,6 +129,10 @@ public class MemoryPostService {
 
         MemoryPostDto memoryPostDto = MemoryPostDto.from(memoryPost);
         List<MemoryPostFamilyMembersDto> membersDtos = MemoryPostFamilyMembersDto.from(memoryPostFamilyMembers);
+        List<MemoryPostFamilyMembersDto> membersDtos = memoryPostFamilyMembers.stream()
+                .map(usersMapper::toMemoryPostFamilyMembersDto)
+                .toList();
+
         boolean isLiked = memoryPostLikeRepository.existsByLikedUserAndMemoryPost(writer, memoryPost);
 
         return GetMemoryPostResponse.from(memoryPostDto, membersDtos, imageDtos, isLiked);
@@ -211,6 +215,9 @@ public class MemoryPostService {
 
         List<MemoryPostFamilyMembers> familyMembers = memoryPostFamilyMembersRepository.findAllByMemoryPost(memoryPost);
         List<MemoryPostFamilyMembersDto> participants = MemoryPostFamilyMembersDto.from(familyMembers);
+        List<MemoryPostFamilyMembersDto> participants = familyMembers.stream()
+                .map(usersMapper::toMemoryPostFamilyMembersDto)
+                .toList();
 
         Users user = usersRepository.findById(userId)
                 .orElseThrow(UsersErrorCode.USER_NOT_FOUND::defaultException);
@@ -284,18 +291,35 @@ public class MemoryPostService {
 
         Map<Long, List<MemoryPostFamilyMembersDto>> participantsList = new HashMap<>();
         Map<Long, Boolean> isLikedList = new HashMap<>();
+        Map<Long, List<MemoryPostFamilyMembersDto>> participantsMap = new HashMap<>();
+        Map<Long, Boolean> isLikedMap = new HashMap<>();
+        Map<Long, String> thumbnailUrlMap = new HashMap<>();
+
         for (MemoryPost memoryPost : memoryPosts) {
             // 참여 가족 구성원 맵핑
             List<MemoryPostFamilyMembers> members = memoryPostFamilyMembersRepository.findAllByMemoryPost(memoryPost);
             List<MemoryPostFamilyMembersDto> memberDtoList = MemoryPostFamilyMembersDto.from(members);
             participantsList.put(memoryPost.getId(), memberDtoList);
+            List<MemoryPostFamilyMembersDto> memberDtoList = members.stream()
+                    .map(usersMapper::toMemoryPostFamilyMembersDto)
+                    .toList();
+            participantsMap.put(memoryPost.getId(), memberDtoList);
 
             // 좋아요 여부 맵핑
             boolean isLiked = memoryPostLikeRepository.existsByLikedUserAndMemoryPost(user, memoryPost);
-            isLikedList.put(memoryPost.getId(), isLiked);
+            isLikedMap.put(memoryPost.getId(), isLiked);
+
+            // 썸네일 URL 추출 및 매핑
+            String thumbnailUrl = memoryPost.getMemoryPostImages().stream()
+                    .filter(img -> img.getImageOrder() != null && img.getImageOrder() == 1)
+                    .findFirst()
+                    .map(MemoryPostImage::getImageKey)
+                    .map(s3Service::generateUrlFromKey)
+                    .orElse(null);
+            thumbnailUrlMap.put(memoryPost.getId(), thumbnailUrl);
         }
 
-        return  GetRecentMemoryPostResponse.from(memoryPostDtoList, participantsList, isLikedList);
+        return  GetRecentMemoryPostResponse.from(memoryPostDtoList, participantsMap, thumbnailUrlMap, isLikedMap);
     }
 
 }

--- a/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
+++ b/src/main/java/com/example/dearfam/domain/memoryposts/memorypost/service/MemoryPostService.java
@@ -23,6 +23,7 @@ import com.example.dearfam.domain.users.dto.FamilyMemberDto;
 import com.example.dearfam.domain.users.entity.UserFamilyRole;
 import com.example.dearfam.domain.users.entity.Users;
 import com.example.dearfam.domain.users.exception.UsersErrorCode;
+import com.example.dearfam.domain.users.mapper.UsersMapper;
 import com.example.dearfam.domain.users.repository.UsersRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,6 +41,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class MemoryPostService {
     private final UsersRepository usersRepository;
+    private final UsersMapper usersMapper;
     private final MemoryPostRepository memoryPostRepository;
     private final MemoryPostFamilyMembersRepository memoryPostFamilyMembersRepository;
     private final MemoryPostLikeRepository memoryPostLikeRepository;
@@ -192,6 +194,7 @@ public class MemoryPostService {
                         })
                         .thenComparing(BaseTimeEntity::getCreatedAt))
                 .map(FamilyMemberDto::from)
+                .map(usersMapper::toFamilyMemberDto)
                 .toList();
 
 

--- a/src/main/java/com/example/dearfam/domain/users/controller/UsersController.java
+++ b/src/main/java/com/example/dearfam/domain/users/controller/UsersController.java
@@ -2,6 +2,7 @@ package com.example.dearfam.domain.users.controller;
 
 import com.example.dearfam.common.dto.response.Response;
 import com.example.dearfam.common.jwt.auth.JwtService;
+import com.example.dearfam.domain.users.controller.response.GetUpdatedProfileImageResponse;
 import com.example.dearfam.domain.users.controller.request.UserNicknameRequest;
 import com.example.dearfam.domain.users.controller.response.GetUserResponse;
 import com.example.dearfam.domain.users.dto.UsersDto;
@@ -12,8 +13,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/users")
@@ -70,4 +75,24 @@ public class UsersController {
         return Response.data("User Nickname Updated");
     }
 
+    @Operation(
+        summary = "프로필 사진 변경",
+        description = "현재 로그인한 유저의 프로필 이미지를 업데이트 합니다.",
+        responses = {
+                @ApiResponse(responseCode = "200", description = "OK"),
+                @ApiResponse(responseCode = "404", description = "USER_NOT_FOUND"),
+                @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
+        }
+    )
+    @PutMapping(value = "/profile-image", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public Response<GetUpdatedProfileImageResponse> updateUserProfileImage(
+            @RequestParam(value = "profileImage", required = false) MultipartFile profileImage) {
+        log.info(profileImage.getContentType());
+        Long userId = jwtService.getTokenDto().getUserId();
+
+        // 프로필 사진 업데이트
+        String profileImageUrl = usersService.updateUserProfileImage(userId, profileImage);
+
+        return Response.data("이미지 업데이트를 완료했습니다", GetUpdatedProfileImageResponse.from(profileImageUrl));
+    }
 }

--- a/src/main/java/com/example/dearfam/domain/users/controller/response/GetUpdatedProfileImageResponse.java
+++ b/src/main/java/com/example/dearfam/domain/users/controller/response/GetUpdatedProfileImageResponse.java
@@ -1,0 +1,21 @@
+package com.example.dearfam.domain.users.controller.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@AllArgsConstructor
+@Builder(access = PRIVATE)
+public class GetUpdatedProfileImageResponse {
+    private String profileImageUrl;
+
+    public static GetUpdatedProfileImageResponse from(String profileImageUrl) {
+        return GetUpdatedProfileImageResponse.builder()
+                .profileImageUrl(profileImageUrl)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/dearfam/domain/users/dto/FamilyMemberDto.java
+++ b/src/main/java/com/example/dearfam/domain/users/dto/FamilyMemberDto.java
@@ -13,24 +13,11 @@ import java.util.stream.Collectors;
 
 @Getter
 @AllArgsConstructor
-@Builder(access = AccessLevel.PRIVATE)
+@Builder
 public class FamilyMemberDto {
     private Long familyMemberId;
     private String familyMemberNickname;
     private UserFamilyRole familyMemberRole;
-    // TODO : 여기에 이미지도 같이 넣지~
+    private String familyMemberProfileImage;
 
-    public static FamilyMemberDto from(Users familyMember) {
-        return FamilyMemberDto.builder()
-                .familyMemberId(familyMember.getId())
-                .familyMemberNickname(familyMember.getUserNickname())
-                .familyMemberRole(familyMember.getUserFamilyRole())
-                .build();
-    }
-
-    public static List<FamilyMemberDto> from(List<Users> familyMembers) {
-        return familyMembers.stream()
-                .map(FamilyMemberDto::from)
-                .collect(Collectors.toList());
-    }
 }

--- a/src/main/java/com/example/dearfam/domain/users/dto/UsersDto.java
+++ b/src/main/java/com/example/dearfam/domain/users/dto/UsersDto.java
@@ -25,23 +25,4 @@ public class UsersDto {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    public static UsersDto from(Users user) {
-        return UsersDto.builder()
-                .id(user.getId())
-                .family(user.getFamily())
-                .userNickName(user.getUserNickname())
-                .userRole(user.getUserRole())
-                .userFamilyRole(user.getUserFamilyRole())
-                .isFamilyRoomManager(user.getIsFamilyRoomManager())
-                .profileImage(user.getProfileImage())
-                .createdAt(user.getCreatedAt())
-                .updatedAt(user.getUpdatedAt())
-                .build();
-    }
-
-    public static List<UsersDto> from(List<Users> users) {
-        return users.stream()
-                .map(UsersDto::from)
-                .collect(Collectors.toList());
-    }
 }

--- a/src/main/java/com/example/dearfam/domain/users/mapper/UsersMapper.java
+++ b/src/main/java/com/example/dearfam/domain/users/mapper/UsersMapper.java
@@ -1,0 +1,39 @@
+package com.example.dearfam.domain.users.mapper;
+
+import com.example.dearfam.common.service.S3Service;
+import com.example.dearfam.domain.users.dto.UsersDto;
+import com.example.dearfam.domain.users.entity.Users;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+// 프로필 이미지 저장시 3가지 종류로 나뉘게 됨 - [null, 카카오 프로필 이미지, 사용자 설정 이미지(S3에 저장)]S3 이미지 저장 시에는,
+// 전체 url 이 아닌 경로 key 만 저장하도록 해놓음. 그래서 Mapper 클래스를 통해 반환할 때 image를 반환할 수 있도록 해야함
+public class UsersMapper {
+
+    private final S3Service s3Service;
+
+    public UsersDto toDto(Users user) {
+        return UsersDto.builder()
+                .id(user.getId())
+                .family(user.getFamily())
+                .userNickName(user.getUserNickname())
+                .userRole(user.getUserRole())
+                .userFamilyRole(user.getUserFamilyRole())
+                .isFamilyRoomManager(user.getIsFamilyRoomManager())
+                .profileImage(resolveProfileImageUrl(user.getProfileImage()))
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
+                .build();
+    }
+
+
+    // 카카오 이미지인지, 사용자 설정 이미지인지 검사 - http 로 시작 시 카카오/profile 로 시작 시 사용자 설정 이미지
+    private String resolveProfileImageUrl(String image) {
+        if (image == null || image.isBlank()) return null;
+        if (image.startsWith("http")) return image;
+        return s3Service.generateUrlFromKey(image);
+    }
+
+}

--- a/src/main/java/com/example/dearfam/domain/users/mapper/UsersMapper.java
+++ b/src/main/java/com/example/dearfam/domain/users/mapper/UsersMapper.java
@@ -1,6 +1,7 @@
 package com.example.dearfam.domain.users.mapper;
 
 import com.example.dearfam.common.service.S3Service;
+import com.example.dearfam.domain.users.dto.FamilyMemberDto;
 import com.example.dearfam.domain.users.dto.UsersDto;
 import com.example.dearfam.domain.users.entity.Users;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,15 @@ public class UsersMapper {
                 .profileImage(resolveProfileImageUrl(user.getProfileImage()))
                 .createdAt(user.getCreatedAt())
                 .updatedAt(user.getUpdatedAt())
+                .build();
+    }
+
+    public FamilyMemberDto toFamilyMemberDto(Users familyMember) {
+        return FamilyMemberDto.builder()
+                .familyMemberId(familyMember.getId())
+                .familyMemberNickname(familyMember.getUserNickname())
+                .familyMemberRole(familyMember.getUserFamilyRole())
+                .familyMemberProfileImage(resolveProfileImageUrl(familyMember.getProfileImage()))
                 .build();
     }
 

--- a/src/main/java/com/example/dearfam/domain/users/mapper/UsersMapper.java
+++ b/src/main/java/com/example/dearfam/domain/users/mapper/UsersMapper.java
@@ -1,6 +1,8 @@
 package com.example.dearfam.domain.users.mapper;
 
 import com.example.dearfam.common.service.S3Service;
+import com.example.dearfam.domain.memoryposts.members.dto.MemoryPostFamilyMembersDto;
+import com.example.dearfam.domain.memoryposts.members.entity.MemoryPostFamilyMembers;
 import com.example.dearfam.domain.users.dto.FamilyMemberDto;
 import com.example.dearfam.domain.users.dto.UsersDto;
 import com.example.dearfam.domain.users.entity.Users;
@@ -38,6 +40,14 @@ public class UsersMapper {
                 .build();
     }
 
+    public MemoryPostFamilyMembersDto toMemoryPostFamilyMembersDto(MemoryPostFamilyMembers memoryPostFamilyMembers) {
+        Users user = memoryPostFamilyMembers.getJoinedFamilyMember();
+        return MemoryPostFamilyMembersDto.builder()
+                .familyMemberId(user.getId())
+                .nickname(user.getUserNickname())
+                .profileImage(resolveProfileImageUrl(user.getProfileImage()))
+                .build();
+    }
 
     // 카카오 이미지인지, 사용자 설정 이미지인지 검사 - http 로 시작 시 카카오/profile 로 시작 시 사용자 설정 이미지
     private String resolveProfileImageUrl(String image) {

--- a/src/main/java/com/example/dearfam/domain/users/service/UsersService.java
+++ b/src/main/java/com/example/dearfam/domain/users/service/UsersService.java
@@ -5,6 +5,7 @@ import com.example.dearfam.common.service.S3Service;
 import com.example.dearfam.domain.users.dto.UsersDto;
 import com.example.dearfam.domain.users.entity.Users;
 import com.example.dearfam.domain.users.exception.UsersErrorCode;
+import com.example.dearfam.domain.users.mapper.UsersMapper;
 import com.example.dearfam.domain.users.repository.UsersRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,13 +21,14 @@ import java.util.Optional;
 public class UsersService {
     private final UsersRepository usersRepository;
     private final S3Service s3Service;
+    private final UsersMapper usersMapper;
 
     @Transactional(readOnly = true)
     public UsersDto getUserDtoById(Long id) {
         Users user = usersRepository.findById(id)
                 .orElseThrow(UsersErrorCode.USER_NOT_FOUND::defaultException);
 
-        return UsersDto.from(user);
+        return usersMapper.toDto(user);
     }
 
     @Transactional

--- a/src/main/java/com/example/dearfam/domain/users/service/UsersService.java
+++ b/src/main/java/com/example/dearfam/domain/users/service/UsersService.java
@@ -1,19 +1,25 @@
 package com.example.dearfam.domain.users.service;
 
+import com.example.dearfam.common.entity.UploadDirectory;
+import com.example.dearfam.common.service.S3Service;
 import com.example.dearfam.domain.users.dto.UsersDto;
 import com.example.dearfam.domain.users.entity.Users;
 import com.example.dearfam.domain.users.exception.UsersErrorCode;
 import com.example.dearfam.domain.users.repository.UsersRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UsersService {
     private final UsersRepository usersRepository;
+    private final S3Service s3Service;
 
     @Transactional(readOnly = true)
     public UsersDto getUserDtoById(Long id) {
@@ -41,5 +47,41 @@ public class UsersService {
 
         user.setUserNickname(newNickname);
         usersRepository.save(user);
+    }
+
+    @Transactional
+    public String updateUserProfileImage(Long userId, MultipartFile profileImage) {
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(UsersErrorCode.USER_NOT_FOUND::defaultException);
+
+        String existingProfileImage = user.getProfileImage();
+        log.info("기존 DB 저장 프로필 이미지: " + existingProfileImage);
+
+        // 기존 이미지 삭제
+        if (existingProfileImage != null && !existingProfileImage.startsWith("http")) {
+            // 기존 S3 URL 일 경우, key 추출 후 삭제
+            s3Service.delete(existingProfileImage);
+            log.info("기존 이미지 삭제 완료 - image: {}", existingProfileImage);
+        }
+
+        // 새 이미지가 없으면 -> 업로드하지 않고 null 저장 (기본 이미지 처리)
+        if (profileImage == null || profileImage.isEmpty()) {
+            user.setProfileImage(null);
+            usersRepository.save(user);
+            log.info("프로필 이미지를 기본 이미지로 초기화함");
+            return null;
+        }
+
+        // 새 이미지 업로드
+        log.info("이미지 업로드 요청");
+        String key = s3Service.upload(profileImage, UploadDirectory.PROFILES, userId);
+
+        // DB 업데이트
+        user.setProfileImage(key); // S3 Key 저장
+        usersRepository.save(user);
+        String imageUrl = s3Service.generateUrlFromKey(key);
+        log.info("이미지 업데이트 완료 - URL: {}", imageUrl);
+
+        return imageUrl;
     }
 }


### PR DESCRIPTION
## 1. S3 업로드 로직 구현 완료
### 이슈
    - 기존에는 게시글만 업로드를 하는 방식이라, 경로 key 값에 'posts' 로 하드코딩이 되어 있었음. 그러나 프로필도 S3에 업로드해야 하는 상황이 됨.
    - 업로드 시 경로를 posts와 profile을 따로 설정해주어야 하는 이슈가 발생.
### 해결
    - UploadDirectory enum 클래스에서 posts와 profile을 구분하였고, S3Service에서 key값을 동적으로 posts와 profile을 경로로 설정하도록 변경함

## 2. 프로필 이미지 업데이트 시 이미지 분별 로직 구현 완료
### 이슈
    - 프로필 이미지를 업데이트 시 카카오 프로필 이미지와 사용자 지정 이미지를 분별해야하는 이슈 발생.
    - 카카오 프로필 이미지는 전체 URL을 저장하지만, 사용자 지정 이미지는 전체 URL을 저장하면, S3의 버킷 네임이 노출되어, posts/profile로 시작하는 key값만 저장함.
    - 기존 Dto에서 from 함수를 통해 단순 엔티티로부터 값을 가져왔음. 그러나 이미지를 분류하기 위해서는 S3Service를 Dto 에서 호출해야하는 상황이 발생해, 역할 분리가 필요함.

### 해결
    - UsersMapper 클래스를 만들어, 이 클래스를 통해 dto 를 빌드하도록 구성함.
    - S3Service를 호출해 이미지의 종류(카카오 or 사용자 지정) 를 판별하고, 각 Dto 에 맞게 빌드하도록 구성.
    - 반환 값으로 Users가 포함된 경우에는 모두 UsersMapper 형식으로 변경.

## 3. 게시글 & 프로필 사진 필요 로직 구현 완료
### 사용자
    - 사용자 프로필 사진 업데이트
    - 사용자 정보 조회 (id 조회 포함)
    - 가족 조회 (id 조회 포함)
    - 게시글 참여 가족 리스트 조회
    - 추억 게시글 생성
    - 최근 10개 게시글 조회
### 게시글
    - 추억 게시글 생성
    - 게시글 단일 조회
    - 전체 게시글 조회
    - 최근 10개 게시글 조회