### PR TITLE
[feat] 카카오 api 주소 허용 및 CORS 설정 추가

### DIFF
--- a/src/main/java/com/example/dearfam/common/configuration/security/SecurityConfiguration.java
+++ b/src/main/java/com/example/dearfam/common/configuration/security/SecurityConfiguration.java
@@ -15,6 +15,11 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -28,10 +33,25 @@ public class SecurityConfiguration {
     private String activeProfile;
 
     @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedOrigin("https://dev.dearfam.store");
+        configuration.addAllowedOrigin("http://localhost:8080");
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.addAllowedHeader("*");
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource resource = new UrlBasedCorsConfigurationSource();
+        resource.registerCorsConfiguration("/**", configuration);
+
+        return resource;
+    }
+
+    @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
-                .cors(cors -> {})
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
 
                 .headers(headers -> headers
                         .frameOptions(HeadersConfigurer.FrameOptionsConfig::disable)
@@ -52,7 +72,8 @@ public class SecurityConfiguration {
                                     .requestMatchers(request -> request.getRequestURI().startsWith("/swagger-ui")).permitAll()
                                     .requestMatchers(request -> request.getRequestURI().startsWith("/v3/api-docs")).permitAll()
                                     .requestMatchers(AntPathRequestMatcher.antMatcher("/dev/ping")).permitAll()
-                                    .requestMatchers(request -> request.getRequestURI().startsWith("/h2-console")).permitAll();
+                                    .requestMatchers(request -> request.getRequestURI().startsWith("/h2-console")).permitAll()
+                                    .requestMatchers(request -> request.getRequestURI().startsWith("/auth/oauth2/login")).permitAll();
 
                             // 로컬환경에서 개발용으로 리프레쉬 토큰 발급 local activeProfile이 local일 때만 사용가능
                             if (activeProfile.equals("local")) {


### PR DESCRIPTION
* 프론트엔드에서 CORS ERROR 이슈가 있었음
    * CORS 설정을 따로 지정을 해놓지 않고 사용해서, CORS 설정 추가함
    * 추가로 카카오 로그인 api 접근 허용하게 함