### PR TITLE
[chore] 카카오 로그인 에러 해결

### DIFF
--- a/src/main/java/com/example/dearfam/domain/auth/service/KakaoService.java
+++ b/src/main/java/com/example/dearfam/domain/auth/service/KakaoService.java
@@ -100,11 +100,11 @@ public class KakaoService implements OAuth2ServiceInterface {
             throw AuthErrorCode.GET_USER_INFO_FAILED_FROM_SOCIAL_PROVIDER.defaultException();
         }
 
-        Object socialUserIdObj =  attributes.get("id");
+        Object socialUserIdObj = attributes.get("id");
         if (socialUserIdObj == null) {
             throw AuthErrorCode.CANNOT_FIND_KAKAO_USER_ID.defaultException();
         }
-        String socialUserId = (String) socialUserIdObj;
+        String socialUserId = String.valueOf(socialUserIdObj);
 
         return OAuth2Attributes.of(attributes, provider, socialUserId);
     }


### PR DESCRIPTION
카카오 id 값은 Long 타입이기 때문에, String 값으로 버로 캐스팅 하면 안됨