### PR TITLE
AI 호출 결과물 조회 로직 생성 & CORS 주소 추가

### DIFF
--- a/src/main/java/com/example/dearfam/common/configuration/security/SecurityConfiguration.java
+++ b/src/main/java/com/example/dearfam/common/configuration/security/SecurityConfiguration.java
@@ -38,7 +38,7 @@ public class SecurityConfiguration {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOriginPatterns(List.of(
                 "https://dearfam-front-end.vercel.app",
-                "https://dev.dearfam.store",
+                "https://api.dearfam.store",
                 "http://localhost:8080",
                 "http://10.10.2.179:8080/"
         ));

--- a/src/main/java/com/example/dearfam/common/configuration/security/SecurityConfiguration.java
+++ b/src/main/java/com/example/dearfam/common/configuration/security/SecurityConfiguration.java
@@ -39,6 +39,7 @@ public class SecurityConfiguration {
         configuration.setAllowedOriginPatterns(List.of(
                 "https://dearfam-front-end.vercel.app",
                 "https://api.dearfam.store",
+                "https://www.dearfam.org",
                 "http://localhost:8080",
                 "http://10.10.2.179:8080/"
         ));

--- a/src/main/java/com/example/dearfam/domain/animatedphoto/controller/AnimatePhotoController.java
+++ b/src/main/java/com/example/dearfam/domain/animatedphoto/controller/AnimatePhotoController.java
@@ -4,7 +4,7 @@ import com.example.dearfam.common.dto.response.Response;
 import com.example.dearfam.common.jwt.auth.JwtService;
 import com.example.dearfam.domain.animatedphoto.controller.request.AnimatePhotoGenerateRequest;
 import com.example.dearfam.domain.animatedphoto.controller.request.AnimatePhotoSaveRequest;
-import com.example.dearfam.domain.animatedphoto.controller.response.GetAnimatePhotoResponse;
+import com.example.dearfam.domain.animatedphoto.controller.response.GetAnimatePhotoTempUrlResponse;
 import com.example.dearfam.domain.animatedphoto.controller.response.GetSavedAnimatePhoto;
 import com.example.dearfam.domain.animatedphoto.service.AnimatePhotoService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -12,7 +12,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.BadRequestException;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -29,7 +28,7 @@ public class AnimatePhotoController {
 
     @Operation(
             summary = "사진 영상화",
-            description = "사진을 프롬프팅과 함께 AI를 호출헤 영상화합니다.",
+            description = "사진을 프롬프팅과 함께 AI를 호출헤 영상화한 후, 미리보기를 위한 임시 주소를 생성합니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "영상화 성공"),
                     @ApiResponse(responseCode = "400", description = "요청 JSON 파싱 실패 또는 이미지 처리 오류"),
@@ -39,7 +38,7 @@ public class AnimatePhotoController {
             }
     )
     @PostMapping(value = "/generate", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
-    public Response<GetAnimatePhotoResponse> generateAnimatePhoto(
+    public Response<GetAnimatePhotoTempUrlResponse> generateAnimatePhoto(
             @Valid @RequestPart("request") String requestJson,
             @RequestPart("image") MultipartFile image
     ) {
@@ -51,7 +50,7 @@ public class AnimatePhotoController {
             throw new IllegalArgumentException("요청 JSON 파싱 실패");
         }
 
-        GetAnimatePhotoResponse response = animatePhotoService.generateAnimatedPhoto(request, image);
+        GetAnimatePhotoTempUrlResponse response = animatePhotoService.generateAnimatedPhoto(request, image);
 
         return Response.data("영상화 완료. 사용자 저장 시 이 영상 주소를 RequestBody 에 넣어주세요.", response);
     }

--- a/src/main/java/com/example/dearfam/domain/animatedphoto/controller/AnimatePhotoController.java
+++ b/src/main/java/com/example/dearfam/domain/animatedphoto/controller/AnimatePhotoController.java
@@ -4,6 +4,7 @@ import com.example.dearfam.common.dto.response.Response;
 import com.example.dearfam.common.jwt.auth.JwtService;
 import com.example.dearfam.domain.animatedphoto.controller.request.AnimatePhotoGenerateRequest;
 import com.example.dearfam.domain.animatedphoto.controller.request.AnimatePhotoSaveRequest;
+import com.example.dearfam.domain.animatedphoto.controller.response.GetAnimatePhotoResponse;
 import com.example.dearfam.domain.animatedphoto.controller.response.GetAnimatePhotoTempUrlResponse;
 import com.example.dearfam.domain.animatedphoto.controller.response.GetSavedAnimatePhoto;
 import com.example.dearfam.domain.animatedphoto.service.AnimatePhotoService;
@@ -91,4 +92,25 @@ public class AnimatePhotoController {
 
         return Response.data("영상을 정상적으로 삭제하였습니다.");
     }
+
+    @Operation(
+            summary = "영상화한 비디오 단일 조회",
+            description = "영상화한 사진의 비디오의 ID로 단일 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "403", description = "같은 가족만 접근 가능"),
+                    @ApiResponse(responseCode = "404", description = "해당 영상을 찾을 수 없습니다."),
+                    @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
+            }
+    )
+    @GetMapping("/{animatePhotoId}")
+    public Response<GetAnimatePhotoResponse> getAnimatePhoto(@PathVariable Long animatePhotoId) {
+        Long userId = jwtService.getTokenDto().getUserId();
+        GetAnimatePhotoResponse response = animatePhotoService.getAnimatePhoto(userId, animatePhotoId);
+
+        return Response.data(response);
+    }
+
+    // TODO : 영상화한 비디오의 전체 조회는 영상의 썸네일 이미지만 보내는 형식으로 추후에 API 추가
+
 }

--- a/src/main/java/com/example/dearfam/domain/animatedphoto/controller/response/GetAnimatePhotoResponse.java
+++ b/src/main/java/com/example/dearfam/domain/animatedphoto/controller/response/GetAnimatePhotoResponse.java
@@ -10,13 +10,13 @@ import static lombok.AccessLevel.PRIVATE;
 @AllArgsConstructor
 @Builder(access = PRIVATE)
 public class GetAnimatePhotoResponse {
-
+    private final Long animatePhotoId;
     private final String animatePhotoUrl;
 
-    public static GetAnimatePhotoResponse from(String animatePhotoUrl) {
+    public static GetAnimatePhotoResponse from(Long animatePhotoId, String animatePhotoUrl) {
         return GetAnimatePhotoResponse.builder()
+                .animatePhotoId(animatePhotoId)
                 .animatePhotoUrl(animatePhotoUrl)
                 .build();
     }
-
 }

--- a/src/main/java/com/example/dearfam/domain/animatedphoto/controller/response/GetAnimatePhotoTempUrlResponse.java
+++ b/src/main/java/com/example/dearfam/domain/animatedphoto/controller/response/GetAnimatePhotoTempUrlResponse.java
@@ -1,0 +1,22 @@
+package com.example.dearfam.domain.animatedphoto.controller.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@AllArgsConstructor
+@Builder(access = PRIVATE)
+public class GetAnimatePhotoTempUrlResponse {
+
+    private final String animatePhotoTempUrl;
+
+    public static GetAnimatePhotoTempUrlResponse from(String animatePhotoTempUrl) {
+        return GetAnimatePhotoTempUrlResponse.builder()
+                .animatePhotoTempUrl(animatePhotoTempUrl)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/dearfam/domain/animatedphoto/exception/AnimatePhotoErrorCode.java
+++ b/src/main/java/com/example/dearfam/domain/animatedphoto/exception/AnimatePhotoErrorCode.java
@@ -9,6 +9,7 @@ public enum AnimatePhotoErrorCode implements ErrorCode {
     RESPONSE_NULL("AI 서버의 응답이 null입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     AI_RESPONSE_FAIL("AI 서버의 응답이 실패 상태입니다.", HttpStatus.BAD_GATEWAY),
     UNAUTHORIZED_VIDEO_DELETE("같은 가족만 삭제가 가능합니다.", HttpStatus.UNAUTHORIZED),
+    UNAUTHORIZED_VIDEO_ACCESS("같은 가족만 접근 가능합니다.", HttpStatus.UNAUTHORIZED),
     VIDEO_NOT_FOUND("영상을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     IMAGE_PROCESSING_ERROR("이미지 파일 처리 중 오류가 발생했습니다.", HttpStatus.BAD_REQUEST),
     AI_SERVER_COMMUNICATION_ERROR("AI 서버와의 통신 중 오류가 발생했습니다.", HttpStatus.GATEWAY_TIMEOUT);

--- a/src/main/java/com/example/dearfam/domain/animatedphoto/service/AnimatePhotoService.java
+++ b/src/main/java/com/example/dearfam/domain/animatedphoto/service/AnimatePhotoService.java
@@ -4,6 +4,7 @@ import com.example.dearfam.common.entity.UploadDirectory;
 import com.example.dearfam.common.service.S3Service;
 import com.example.dearfam.domain.animatedphoto.controller.request.AnimatePhotoGenerateRequest;
 import com.example.dearfam.domain.animatedphoto.controller.request.AnimatePhotoSaveRequest;
+import com.example.dearfam.domain.animatedphoto.controller.response.GetAnimatePhotoResponse;
 import com.example.dearfam.domain.animatedphoto.controller.response.GetAnimatePhotoTempUrlResponse;
 import com.example.dearfam.domain.animatedphoto.controller.response.GetSavedAnimatePhoto;
 import com.example.dearfam.domain.animatedphoto.dto.AiAnimatePhotoDto;
@@ -113,6 +114,32 @@ public class AnimatePhotoService {
         animatePhotoRepository.delete(animatePhoto);
         log.info("[영상화 삭제] DB 삭제 완료");
 
+    }
+
+    @Transactional(readOnly = true)
+    public GetAnimatePhotoResponse getAnimatePhoto(Long userId, Long animatePhotoId) {
+        log.info("[영상화 단건 조회] 사용자 ID: {}, animatePhotoId: {}", userId, animatePhotoId);
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(() -> {
+                    log.error("[영상화 단건 조회] 사용자 조회 실패 - userId: {}", userId);
+                    return UsersErrorCode.USER_NOT_FOUND.defaultException();
+                });
+
+        AnimatePhoto animatePhoto = animatePhotoRepository.findById(animatePhotoId)
+                .orElseThrow(() -> {
+                    log.error("[영상화 단건 조회] 영상 조회 실패 - animatePhotoId: {}", animatePhotoId);
+                    return AnimatePhotoErrorCode.VIDEO_NOT_FOUND.defaultException();
+                });
+
+        if (!user.getFamily().getId().equals(animatePhoto.getFamily().getId())) {
+            log.warn("[영상화 단건 조회] 권한 없음 - userFamilyId: {}, animatePhotoFamilyId: {}",
+                    user.getFamily().getId(), animatePhoto.getFamily().getId());
+            throw AnimatePhotoErrorCode.UNAUTHORIZED_VIDEO_DELETE.defaultException();
+        }
+
+        String videoUrl = s3Service.generateUrlFromKey(animatePhoto.getAnimatePhoto());
+        log.info("[영상화 단건 조회] 조회 성공 - animatePhotoId: {}", animatePhotoId);
+        return GetAnimatePhotoResponse.from(animatePhoto.getId(), videoUrl);
     }
 
     private String callAiServer(MultipartFile image, String actionPrompt) {

--- a/src/main/java/com/example/dearfam/domain/animatedphoto/service/AnimatePhotoService.java
+++ b/src/main/java/com/example/dearfam/domain/animatedphoto/service/AnimatePhotoService.java
@@ -4,13 +4,12 @@ import com.example.dearfam.common.entity.UploadDirectory;
 import com.example.dearfam.common.service.S3Service;
 import com.example.dearfam.domain.animatedphoto.controller.request.AnimatePhotoGenerateRequest;
 import com.example.dearfam.domain.animatedphoto.controller.request.AnimatePhotoSaveRequest;
-import com.example.dearfam.domain.animatedphoto.controller.response.GetAnimatePhotoResponse;
+import com.example.dearfam.domain.animatedphoto.controller.response.GetAnimatePhotoTempUrlResponse;
 import com.example.dearfam.domain.animatedphoto.controller.response.GetSavedAnimatePhoto;
 import com.example.dearfam.domain.animatedphoto.dto.AiAnimatePhotoDto;
 import com.example.dearfam.domain.animatedphoto.entity.AnimatePhoto;
 import com.example.dearfam.domain.animatedphoto.exception.AnimatePhotoErrorCode;
 import com.example.dearfam.domain.animatedphoto.repository.AnimatePhotoRepository;
-import com.example.dearfam.domain.diary.exception.DiaryErrorCode;
 import com.example.dearfam.domain.family.entity.Family;
 import com.example.dearfam.domain.family.exception.FamilyErrorCode;
 import com.example.dearfam.domain.users.entity.Users;
@@ -48,14 +47,14 @@ public class AnimatePhotoService {
     @Value("${ai.server.url}")
     private String aiServerUrl;
 
-    public GetAnimatePhotoResponse generateAnimatedPhoto (AnimatePhotoGenerateRequest request, MultipartFile image) {
+    public GetAnimatePhotoTempUrlResponse generateAnimatedPhoto (AnimatePhotoGenerateRequest request, MultipartFile image) {
         String actionPrompt = request.getActionPrompt();
         log.info("AI 서버에 사진 영상화를 요청합니다. prompt: {}", actionPrompt);
 
         String videoUrl = callAiServer(image, actionPrompt);
         log.info("사진 영상화 완료. 영상 주소: {}", videoUrl);
 
-        return GetAnimatePhotoResponse.from(videoUrl);
+        return GetAnimatePhotoTempUrlResponse.from(videoUrl);
     }
 
     @Transactional

--- a/src/main/java/com/example/dearfam/domain/diary/controller/DiaryBookController.java
+++ b/src/main/java/com/example/dearfam/domain/diary/controller/DiaryBookController.java
@@ -101,6 +101,8 @@ public class DiaryBookController {
             description = "그림일기를 하나씩 볼 때 그림일기 ID를 통해 조회합니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "401", description = "UNAUTHORIZED_DIARY_ACCESS"),
+                    @ApiResponse(responseCode = "404", description = "USER_NOT_FOUND, DIARY_NOT_FOUND"),
                     @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
             }
     )

--- a/src/main/java/com/example/dearfam/domain/diary/controller/DiaryBookController.java
+++ b/src/main/java/com/example/dearfam/domain/diary/controller/DiaryBookController.java
@@ -3,6 +3,7 @@ package com.example.dearfam.domain.diary.controller;
 import com.example.dearfam.common.dto.response.Response;
 import com.example.dearfam.common.jwt.auth.JwtService;
 import com.example.dearfam.domain.diary.controller.request.DiaryGenerateRequest;
+import com.example.dearfam.domain.diary.controller.response.GetAllDiariesResponse;
 import com.example.dearfam.domain.diary.controller.response.GetDiaryResponse;
 import com.example.dearfam.domain.diary.controller.response.GetSavedDiaryResponse;
 import com.example.dearfam.domain.diary.service.DiaryBookService;
@@ -13,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 
 @RequiredArgsConstructor
@@ -75,6 +78,23 @@ public class DiaryBookController {
         return Response.data("그림일기를 삭제했습니다.");
     }
 
+    @Operation(
+            summary = "그림일기 전체 조회",
+            description = "책장에서 보여질 가족의 그림일기들을 모두 조회합니다",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "404", description = "USER_NOT_FOUND"),
+                    @ApiResponse(responseCode = "404", description = "FAMILY_NOT_FOUND"),
+                    @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
+            }
+    )
+    @GetMapping("/all")
+    public Response<List<GetAllDiariesResponse>> getAllDiary() {
+        Long userId = jwtService.getTokenDto().getUserId();
+        List<GetAllDiariesResponse> responseList = diaryBookService.getAllDiaries(userId);
+
+        return Response.data(responseList);
+    }
 }
 
 

--- a/src/main/java/com/example/dearfam/domain/diary/controller/DiaryBookController.java
+++ b/src/main/java/com/example/dearfam/domain/diary/controller/DiaryBookController.java
@@ -3,7 +3,7 @@ package com.example.dearfam.domain.diary.controller;
 import com.example.dearfam.common.dto.response.Response;
 import com.example.dearfam.common.jwt.auth.JwtService;
 import com.example.dearfam.domain.diary.controller.request.DiaryGenerateRequest;
-import com.example.dearfam.domain.diary.controller.response.GetAllDiariesResponse;
+import com.example.dearfam.domain.diary.controller.response.GetDiaryUrlResponse;
 import com.example.dearfam.domain.diary.controller.response.GetDiaryResponse;
 import com.example.dearfam.domain.diary.controller.response.GetSavedDiaryResponse;
 import com.example.dearfam.domain.diary.service.DiaryBookService;
@@ -89,12 +89,29 @@ public class DiaryBookController {
             }
     )
     @GetMapping("/all")
-    public Response<List<GetAllDiariesResponse>> getAllDiary() {
+    public Response<List<GetDiaryUrlResponse>> getAllDiary() {
         Long userId = jwtService.getTokenDto().getUserId();
-        List<GetAllDiariesResponse> responseList = diaryBookService.getAllDiaries(userId);
+        List<GetDiaryUrlResponse> responseList = diaryBookService.getAllDiaries(userId);
 
         return Response.data(responseList);
     }
+
+    @Operation(
+            summary = "그림일기 ID로 조회",
+            description = "그림일기를 하나씩 볼 때 그림일기 ID를 통해 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
+            }
+    )
+    @GetMapping("/{diaryBookId}")
+    public Response<GetDiaryUrlResponse> getDiaryById(@PathVariable Long diaryBookId) {
+        Long userId = jwtService.getTokenDto().getUserId();
+        GetDiaryUrlResponse response = diaryBookService.getDiary(userId, diaryBookId);
+
+        return Response.data(response);
+    }
+
 }
 
 

--- a/src/main/java/com/example/dearfam/domain/diary/controller/response/GetAllDiariesResponse.java
+++ b/src/main/java/com/example/dearfam/domain/diary/controller/response/GetAllDiariesResponse.java
@@ -1,0 +1,27 @@
+package com.example.dearfam.domain.diary.controller.response;
+
+import com.example.dearfam.domain.diary.entity.DiaryBook;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@AllArgsConstructor
+@Builder(access = PRIVATE)
+public class GetAllDiariesResponse {
+
+    private final Long diaryBookId;
+    private final String diaryImageUrl;
+
+    public static GetAllDiariesResponse from(Long diaryBookId, String diaryImageUrl) {
+        return GetAllDiariesResponse.builder()
+                .diaryBookId(diaryBookId)
+                .diaryImageUrl(diaryImageUrl)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/dearfam/domain/diary/controller/response/GetDiaryUrlResponse.java
+++ b/src/main/java/com/example/dearfam/domain/diary/controller/response/GetDiaryUrlResponse.java
@@ -1,24 +1,22 @@
 package com.example.dearfam.domain.diary.controller.response;
 
-import com.example.dearfam.domain.diary.entity.DiaryBook;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.util.List;
 
 import static lombok.AccessLevel.PRIVATE;
 
 @Getter
 @AllArgsConstructor
 @Builder(access = PRIVATE)
-public class GetAllDiariesResponse {
+public class GetDiaryUrlResponse {
 
     private final Long diaryBookId;
     private final String diaryImageUrl;
 
-    public static GetAllDiariesResponse from(Long diaryBookId, String diaryImageUrl) {
-        return GetAllDiariesResponse.builder()
+    public static GetDiaryUrlResponse from(Long diaryBookId, String diaryImageUrl) {
+        return GetDiaryUrlResponse.builder()
                 .diaryBookId(diaryBookId)
                 .diaryImageUrl(diaryImageUrl)
                 .build();

--- a/src/main/java/com/example/dearfam/domain/diary/exception/DiaryErrorCode.java
+++ b/src/main/java/com/example/dearfam/domain/diary/exception/DiaryErrorCode.java
@@ -10,6 +10,7 @@ public enum DiaryErrorCode implements ErrorCode {
     IMAGE_FILE_EMPTY("일기 이미지 파일이 비어 있습니다.", HttpStatus.BAD_REQUEST),
     MEMORY_POST_NOT_FOUND("해당 ID의 게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     DIARY_BOOK_NOT_FOUND("해당 그림일기를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    UNAUTHORIZED_DIARY_ACCESS("같은 가족만 접근이 가능합니다.", HttpStatus.UNAUTHORIZED),
     UNAUTHORIZED_DIARY_DELETE("같은 가족만 삭제가 가능합니다.", HttpStatus.UNAUTHORIZED),
     AI_SERVER_FAILED("AI 서버로부터 그림일기 콘텐츠를 생성하지 못했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     AI_COMMUNICATION_ERROR("AI 서버와 통신 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/example/dearfam/domain/diary/repository/DiaryBookRepository.java
+++ b/src/main/java/com/example/dearfam/domain/diary/repository/DiaryBookRepository.java
@@ -1,7 +1,13 @@
 package com.example.dearfam.domain.diary.repository;
 
 import com.example.dearfam.domain.diary.entity.DiaryBook;
+import com.example.dearfam.domain.family.entity.Family;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface DiaryBookRepository extends JpaRepository<DiaryBook, Long> {
+
+    List<DiaryBook> findAllByFamilyOrderByCreatedAtDesc(Family family);
+
 }

--- a/src/main/java/com/example/dearfam/domain/diary/service/DiaryBookService.java
+++ b/src/main/java/com/example/dearfam/domain/diary/service/DiaryBookService.java
@@ -3,7 +3,7 @@
     import com.example.dearfam.common.entity.UploadDirectory;
     import com.example.dearfam.common.service.S3Service;
     import com.example.dearfam.domain.diary.controller.request.DiaryGenerateRequest;
-    import com.example.dearfam.domain.diary.controller.response.GetAllDiariesResponse;
+    import com.example.dearfam.domain.diary.controller.response.GetDiaryUrlResponse;
     import com.example.dearfam.domain.diary.controller.response.GetDiaryResponse;
     import com.example.dearfam.domain.diary.controller.response.GetSavedDiaryResponse;
     import com.example.dearfam.domain.diary.dto.DiaryContentDto;
@@ -138,7 +138,7 @@
         }
 
         @Transactional(readOnly = true)
-        public List<GetAllDiariesResponse> getAllDiaries(Long userId) {
+        public List<GetDiaryUrlResponse> getAllDiaries(Long userId) {
             log.info("[그림일기 전체 조회] 사용자 ID: {}", userId);
 
             Users user = usersRepository.findById(userId)
@@ -155,13 +155,40 @@
 
             List<DiaryBook> diaryBookList = diaryBookRepository.findAllByFamilyOrderByCreatedAtDesc(family);
             log.info("[그림일기 전체 조회] 가족 ID {}에 대한 {}개의 그림일기 조회", family.getId(), diaryBookList.size());
-            List<GetAllDiariesResponse> responseList = new ArrayList<>();
+            List<GetDiaryUrlResponse> responseList = new ArrayList<>();
             for (DiaryBook diaryBook : diaryBookList) {
                 String imageUrl = s3Service.generateUrlFromKey(diaryBook.getDiaryImage());
-                GetAllDiariesResponse response = GetAllDiariesResponse.from(diaryBook.getId(), imageUrl);
+                GetDiaryUrlResponse response = GetDiaryUrlResponse.from(diaryBook.getId(), imageUrl);
                 responseList.add(response);
             }
             return responseList;
+        }
+
+        @Transactional(readOnly = true)
+        public GetDiaryUrlResponse getDiary(Long userId, Long diaryBookId) {
+            log.info("[그림일기 단일 조회] 사용자 ID: {}, diaryId: {}", userId, diaryBookId);
+
+            Users user = usersRepository.findById(userId)
+                    .orElseThrow(() -> {
+                        log.warn("[그림일기 단일 조회] 사용자 조회 실패 - userId: {}", userId);
+                        return UsersErrorCode.USER_NOT_FOUND.defaultException();
+                    });
+            DiaryBook diaryBook = diaryBookRepository.findById(diaryBookId)
+                    .orElseThrow(() -> {
+                        log.warn("[그림일기 단건 조회] 일기 조회 실패 - diaryBookId: {}", diaryBookId);
+                        return DiaryErrorCode.DIARY_BOOK_NOT_FOUND.defaultException();
+                    });
+
+            // 사용자가 소속된 가족과 일기의 가족이 다르면 삭제 불가
+            if (!user.getFamily().getId().equals(diaryBook.getFamily().getId())) {
+                log.warn("[그림일기 단건 조회] 권한 없음 - userFamilyId: {}, diaryFamilyId: {}",
+                        user.getFamily().getId(), diaryBook.getFamily().getId());
+                throw DiaryErrorCode.UNAUTHORIZED_DIARY_ACCESS.defaultException();
+            }
+
+            String imageUrl = s3Service.generateUrlFromKey(diaryBook.getDiaryImage());
+            log.info("[그림일기 단건 조회] 완료 - imageUrl: {}", imageUrl);
+            return GetDiaryUrlResponse.from(diaryBook.getId(), imageUrl);
         }
 
         // 그림일기 호출 메서드

--- a/src/main/java/com/example/dearfam/domain/diary/service/DiaryBookService.java
+++ b/src/main/java/com/example/dearfam/domain/diary/service/DiaryBookService.java
@@ -3,6 +3,7 @@
     import com.example.dearfam.common.entity.UploadDirectory;
     import com.example.dearfam.common.service.S3Service;
     import com.example.dearfam.domain.diary.controller.request.DiaryGenerateRequest;
+    import com.example.dearfam.domain.diary.controller.response.GetAllDiariesResponse;
     import com.example.dearfam.domain.diary.controller.response.GetDiaryResponse;
     import com.example.dearfam.domain.diary.controller.response.GetSavedDiaryResponse;
     import com.example.dearfam.domain.diary.dto.DiaryContentDto;
@@ -134,6 +135,33 @@
             diaryBookRepository.delete(diaryBook);
             log.info("[그림일기 삭제] 삭제 완료");
 
+        }
+
+        @Transactional(readOnly = true)
+        public List<GetAllDiariesResponse> getAllDiaries(Long userId) {
+            log.info("[그림일기 전체 조회] 사용자 ID: {}", userId);
+
+            Users user = usersRepository.findById(userId)
+                    .orElseThrow(() -> {
+                        log.error("[그림일기 전체 조회] 사용자 조회 실패 - userId: {}", userId);
+                        return UsersErrorCode.USER_NOT_FOUND.defaultException();
+                    });
+
+            Family family = user.getFamily();
+            if (family == null) {
+                log.error("[그림일기 전체 조회] 사용자에 대한 가족 정보가 없음 - userId: {}", userId);
+                throw FamilyErrorCode.FAMILY_NOT_FOUND.defaultException();
+            }
+
+            List<DiaryBook> diaryBookList = diaryBookRepository.findAllByFamilyOrderByCreatedAtDesc(family);
+            log.info("[그림일기 전체 조회] 가족 ID {}에 대한 {}개의 그림일기 조회", family.getId(), diaryBookList.size());
+            List<GetAllDiariesResponse> responseList = new ArrayList<>();
+            for (DiaryBook diaryBook : diaryBookList) {
+                String imageUrl = s3Service.generateUrlFromKey(diaryBook.getDiaryImage());
+                GetAllDiariesResponse response = GetAllDiariesResponse.from(diaryBook.getId(), imageUrl);
+                responseList.add(response);
+            }
+            return responseList;
         }
 
         // 그림일기 호출 메서드


### PR DESCRIPTION
1. 그림일기 조회
    * 전체 그림일기 조회 -> 책장에서 그림일기 탭에서 사용
    * ID로 단일 조회 -> 사용자에게 하나씩 보여줄 때 사용
2. 영상화된 사진 비디오 조회
    * 전체 조회는 만들지 않았음. 현재 영상의 주소를 반환하는데, 전체 조회는 책장에서 썸네일이 주력으로 보여지면 되는 경우이기에, 썸네일을 보내는 식으로 진행 예정. (보류)
    * ID로 단일 조회 -> 사용자에게 하나씩 보여줄 때 사용

3. CORS 에 프론트엔드 & 백엔드 배포 도메인 주소를 입력함