### PR TITLE
[feat] 로그아웃 & 회원탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/example/dearfam/common/service/S3Service.java
+++ b/src/main/java/com/example/dearfam/common/service/S3Service.java
@@ -10,16 +10,11 @@ import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
-import software.amazon.awssdk.services.s3.model.GetUrlRequest;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.*;
 
 import java.io.IOException;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -106,6 +101,30 @@ public class S3Service {
             log.info("S3 이미지 삭제 성공 - key: {}", key);
         } catch (SdkException e) {
             log.error("S3 이미지 삭제 실패 - key: {}", key, e);
+            throw S3ErrorCode.DELETE_FAILED.defaultException(e);
+        }
+    }
+
+    public void deleteAllByKeys(List<String> keys) {
+        if (keys == null || keys.isEmpty()) {
+            log.info("삭제할 S3 키가 없습니다.");
+            return;
+        }
+
+        List<ObjectIdentifier> toDelete = keys.stream()
+                .map(key -> ObjectIdentifier.builder().key(key).build())
+                .collect(Collectors.toList());
+
+        try {
+            DeleteObjectsRequest deleteObjectsRequest = DeleteObjectsRequest.builder()
+                    .bucket(bucket)
+                    .delete(Delete.builder().objects(toDelete).build())
+                    .build();
+
+            s3Client.deleteObjects(deleteObjectsRequest);
+            log.info("S3 객체 {}개 일괄 삭제 성공.", keys.size());
+        } catch (SdkException e) {
+            log.error("S3 객체 일괄 삭제 실패.", e);
             throw S3ErrorCode.DELETE_FAILED.defaultException(e);
         }
     }

--- a/src/main/java/com/example/dearfam/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/dearfam/domain/auth/controller/AuthController.java
@@ -1,0 +1,57 @@
+package com.example.dearfam.domain.auth.controller;
+
+import com.example.dearfam.common.dto.response.Response;
+import com.example.dearfam.common.jwt.auth.JwtService;
+import com.example.dearfam.domain.auth.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+@Tag(name = "Auth Controller", description = "로그아웃, 회원탈퇴 기능 관리 컨트롤러")
+public class AuthController {
+
+    private final JwtService jwtService;
+    private final AuthService authService;
+
+    @Operation(
+            summary = "로그아웃",
+            description = "로그아웃 시 서버에 저장된 리프레쉬 토큰을 무효화합니다",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "404", description = "USER_NOT_FOUND"),
+                    @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
+            }
+    )
+    @PostMapping("/logout")
+    public Response<String> logout() {
+        Long userId = jwtService.getTokenDto().getUserId();
+        authService.logout(userId);
+
+        return Response.data("로그아웃 성공");
+    }
+
+    @Operation(
+            summary = "회원 탈퇴",
+            description = "서비스에서 완전히 탈퇴하고 모든 정보를 삭제합니다. 가족의 마지막 멤버일 경우 모든 가족 데이터가 삭제됩니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "404", description = "USER_NOT_FOUND"),
+                    @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
+            }
+    )
+    @DeleteMapping("/withdraw")
+    public Response<String> withdraw() {
+        Long userId = jwtService.getTokenDto().getUserId();
+        authService.withdrawUser(userId);
+        return Response.data("회원 탈퇴가 성공적으로 처리되었습니다.");
+    }
+
+}

--- a/src/main/java/com/example/dearfam/domain/auth/kakao/KakaoClient.java
+++ b/src/main/java/com/example/dearfam/domain/auth/kakao/KakaoClient.java
@@ -1,0 +1,46 @@
+package com.example.dearfam.domain.auth.kakao;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KakaoClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${kakao.api.url.unlink}")
+    private String kakaoUnlinkUrl;
+
+    @Value("${kakao.admin.key}")
+    private String kakaoAdminKey;
+
+    public void unlinkUser(String socialUserId) {
+        HttpHeaders headers = new HttpHeaders();
+        // Authorization 헤더에 "KakaoAK {어드민 키}" 형태로 담아야 합니다.
+        headers.set("Authorization", "KakaoAK " + kakaoAdminKey);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("target_id_type", "user_id");
+        body.add("target_id", socialUserId);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+
+        try {
+            restTemplate.postForEntity(kakaoUnlinkUrl, request, String.class);
+            log.info("카카오 연결 끊기 성공. socialUserId: {}", socialUserId);
+        } catch (Exception e) {
+            log.error("카카오 연결 끊기 실패. socialUserId: {}", socialUserId, e);
+            // 여기서 예외를 던져서 탈퇴 프로세스를 중단시키는 것이 좋습니다.
+            throw new RuntimeException("카카오 연결 끊기에 실패했습니다.");
+        }
+    }
+}

--- a/src/main/java/com/example/dearfam/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/dearfam/domain/auth/service/AuthService.java
@@ -1,0 +1,117 @@
+package com.example.dearfam.domain.auth.service;
+
+import com.example.dearfam.common.service.S3Service;
+import com.example.dearfam.domain.auth.kakao.KakaoClient;
+import com.example.dearfam.domain.family.entity.Family;
+import com.example.dearfam.domain.family.exception.FamilyErrorCode;
+import com.example.dearfam.domain.family.repository.FamilyRepository;
+import com.example.dearfam.domain.users.entity.Users;
+import com.example.dearfam.domain.users.exception.UsersErrorCode;
+import com.example.dearfam.domain.users.repository.UsersRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UsersRepository usersRepository;
+    private final FamilyRepository familyRepository;
+    private final KakaoClient kakaoClient;
+    private final S3Service s3Service;
+
+    @Transactional
+    public void logout(Long userId) {
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(UsersErrorCode.USER_NOT_FOUND::defaultException);
+
+        user.setRefreshToken(null); // DB에 저장된 Refresh Token을 무효화
+        usersRepository.save(user);
+
+        log.info("로그아웃 처리 완료. userId: {}", userId);
+    }
+
+
+    @Transactional
+    public void withdrawUser(Long userId) {
+        log.info("[회원 탈퇴] 시작 - userId: {}", userId);
+
+        // 1. 사용자 정보 조회
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(UsersErrorCode.USER_NOT_FOUND::defaultException);
+
+        // 2. 카카오 연결 끊기 (가장 먼저 수행하는 것이 안전)
+        kakaoClient.unlinkUser(user.getSocialUserId());
+
+        // 3. 가족 호출
+        Family family = user.getFamily();
+
+        // 4. 가족이 없는 경우 오류
+        if (family == null) {
+            log.error("소속된 가족이 없습니다. userId: {}", userId);
+            throw FamilyErrorCode.FAMILY_NOT_FOUND.defaultException();
+        }
+
+        int memberCount = usersRepository.countByFamily(family);
+
+        if (memberCount > 1) {
+            // 마지막 멤버가 아닌 경우: 사용자 정보만 삭제
+            log.info("가족에 다른 멤버가 남아있어 사용자 정보만 삭제합니다. familyId: {}, 남은 멤버 수: {}", family.getId(), memberCount - 1);
+            deleteProfileImageFromS3(user.getProfileImage());
+            usersRepository.delete(user); // Family 데이터는 그대로 유지됨
+        } else {
+            // 마지막 멤버인 경우: 모든 가족 데이터 삭제
+            log.warn("가족의 마지막 멤버입니다. 모든 가족 데이터를 삭제합니다. familyId: {}", family.getId());
+
+            // S3에서 삭제할 모든 파일 키 수집
+            List<String> keysToDelete = collectAllFamilyS3Keys(family);
+
+            // S3에서 일괄 삭제
+            s3Service.deleteAllByKeys(keysToDelete);
+
+            // DB에서 Family를 삭제하면, Cascade 설정에 따라 모든 관련 데이터가 연쇄적으로 삭제됨
+            familyRepository.delete(family);
+            log.info("Family 및 모든 연관 데이터(Users, Posts, Diaries, Videos) DB에서 삭제 완료.");
+        }
+        log.info("[회원 탈퇴] 완료 - userId: {}", userId);
+    }
+
+    private List<String> collectAllFamilyS3Keys(Family family) {
+        List<String> keysToDelete = new ArrayList<>();
+
+        // 1. 가족 구성원들의 프로필 이미지 키 수집
+        family.getUsers().forEach(member -> {
+            if (member.getProfileImage() != null && !member.getProfileImage().startsWith("http")) {
+                keysToDelete.add(member.getProfileImage());
+            }
+        });
+
+        // 2. 그림일기 이미지 키 수집
+        family.getDiaryBooks().forEach(diary -> keysToDelete.add(diary.getDiaryImage()));
+
+        // 3. 영상화된 사진 키 수집
+        family.getAnimatePhotos().forEach(video -> keysToDelete.add(video.getAnimatePhoto()));
+
+        // 4. 추억 게시글의 모든 이미지 키 수집
+        family.getMemoryPosts().forEach(post ->
+                post.getMemoryPostImages().forEach(image ->
+                        keysToDelete.add(image.getImageKey())
+                )
+        );
+
+        return keysToDelete;
+    }
+
+
+    private void deleteProfileImageFromS3(String key) {
+        if (key != null && !key.startsWith("http")) {
+            s3Service.delete(key);
+        }
+    }
+}

--- a/src/main/java/com/example/dearfam/domain/family/entity/Family.java
+++ b/src/main/java/com/example/dearfam/domain/family/entity/Family.java
@@ -1,11 +1,18 @@
 package com.example.dearfam.domain.family.entity;
 
 import com.example.dearfam.common.entity.BaseTimeEntity;
+import com.example.dearfam.domain.animatedphoto.entity.AnimatePhoto;
+import com.example.dearfam.domain.diary.entity.DiaryBook;
+import com.example.dearfam.domain.memoryposts.memorypost.entity.MemoryPost;
+import com.example.dearfam.domain.users.entity.Users;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 @Getter
@@ -28,6 +35,18 @@ public class Family extends BaseTimeEntity {
 
     @Column(name = "child_count")
     private Integer childCount;
+
+    @OneToMany(mappedBy = "family", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Users> users = new ArrayList<>();
+
+    @OneToMany(mappedBy = "family", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MemoryPost> memoryPosts = new ArrayList<>();
+
+    @OneToMany(mappedBy = "family", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DiaryBook> diaryBooks = new ArrayList<>();
+
+    @OneToMany(mappedBy = "family", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<AnimatePhoto> animatePhotos = new ArrayList<>();
 
     @Builder
     public Family(Long id, String familyName, Integer parentCount, Integer childCount) {

--- a/src/main/java/com/example/dearfam/domain/users/repository/UsersRepository.java
+++ b/src/main/java/com/example/dearfam/domain/users/repository/UsersRepository.java
@@ -14,4 +14,5 @@ public interface UsersRepository extends JpaRepository<Users, Long> {
     List<Users> findAllByFamily(Family family);
     Optional<Users> findByEmail(String email);
     List<Users> findAllByFamilyId(Long familyId);
+    int countByFamily(Family family);
 }


### PR DESCRIPTION
1. 로그아웃
* 로그아웃 시에는 리프레쉬 토큰만 null 값으로 변경하여 무효화함.

2. 회원탈퇴
* 회원탈퇴 시, 카카오에 요청을 보내 카카오 social_user_id 를 무효화해, 재로그인이 되는 것을 방지
* 탈퇴 시, 가족 멤버가 1명 이상 남아있을 경우에는 사용자 개인 정보만 삭제됨.
* 만약 마지막 가족 멤버가 탈퇴 시, 유저 및 가족 데이터 모두 삭제